### PR TITLE
Multiple exit page translations

### DIFF
--- a/app/controllers/forms/welsh_translation_controller.rb
+++ b/app/controllers/forms/welsh_translation_controller.rb
@@ -3,14 +3,25 @@ module Forms
     def new
       authorize current_form, :can_edit_form?
 
-      @welsh_translation_input = WelshTranslationInput.new(form: form_with_pages_and_conditions).assign_form_values
+      @welsh_translation_input = if FeatureService.new(group: current_form.group).enabled?(:multiple_branches)
+                                   WelshTranslationInput2.new(form: form_with_pages_and_exit_pages).assign_form_values
+                                 else
+                                   WelshTranslationInput.new(form: form_with_pages_and_conditions).assign_form_values
+                                 end
+
       @table_presenter = Forms::TranslationTablePresenter.new
+      @current_form = current_form
     end
 
     def create
       authorize current_form, :can_edit_form?
 
-      @welsh_translation_input = WelshTranslationInput.new(welsh_translation_params)
+      @welsh_translation_input = if FeatureService.new(group: current_form.group).enabled?(:multiple_branches)
+                                   WelshTranslationInput2.new(welsh_translation_params2)
+                                 else
+                                   WelshTranslationInput.new(welsh_translation_params)
+                                 end
+
       @table_presenter = Forms::TranslationTablePresenter.new
 
       if @welsh_translation_input.blanked?
@@ -89,12 +100,27 @@ module Forms
       ).merge(form: current_form)
     end
 
+    def welsh_translation_params2
+      params.require(:forms_welsh_translation_input2).permit(
+        *WelshTranslationInput2.attribute_names,
+        page_translations_attributes: [
+          *WelshPageTranslationInput2.attribute_names,
+          { selection_options_cy_attributes: %i[id name_cy] },
+          { exit_page_translations_attributes: WelshExitPageTranslationInput.attribute_names },
+        ],
+      ).merge(form: current_form)
+    end
+
     def delete_welsh_translation_params
       params.require(:forms_delete_welsh_translation_input).permit(:confirm).merge(form: current_form)
     end
 
     def form_with_pages_and_conditions
       Form.includes(pages: [:routing_conditions]).find(current_form.id)
+    end
+
+    def form_with_pages_and_exit_pages
+      Form.includes(pages: [:exit_pages]).find(current_form.id)
     end
   end
 end

--- a/app/input_objects/forms/delete_welsh_translation_input.rb
+++ b/app/input_objects/forms/delete_welsh_translation_input.rb
@@ -19,6 +19,7 @@ private
     reset_form_translations
     reset_page_translations
     reset_condition_translations
+    reset_exit_page_translations
   end
 
   def reset_form_translations
@@ -35,6 +36,10 @@ private
 
   def reset_condition_translations
     Condition::Translation.where(locale: :cy, condition_id: form.condition_ids).delete_all
+  end
+
+  def reset_exit_page_translations
+    ExitPage::Translation.where(locale: :cy, exit_page_id: form.exit_page_ids).delete_all
   end
 
   def clear_translated_fields(model, object)

--- a/app/input_objects/forms/welsh_exit_page_translation_input.rb
+++ b/app/input_objects/forms/welsh_exit_page_translation_input.rb
@@ -1,0 +1,88 @@
+class Forms::WelshExitPageTranslationInput < BaseInput
+  include ActionView::Helpers::FormTagHelper
+  include ActiveModel::Attributes
+
+  attr_accessor :exit_page, :position
+
+  attribute :id
+  attribute :position
+
+  attribute :heading_cy
+  attribute :markdown_cy
+
+  validate :heading_cy_present?, on: :mark_complete
+  validate :heading_cy_length, if: -> { heading_cy.present? }
+
+  validate :markdown_cy_present?, on: :mark_complete
+  validate :markdown_cy_length_and_tags, if: -> { markdown_cy.present? }
+
+  def initialize(attributes = {})
+    @exit_page = attributes.delete(:exit_page) if attributes.key?(:exit_page)
+    @position = attributes.delete(:position)
+    super
+    self.id ||= @exit_page&.id
+  end
+
+  def submit
+    return false if invalid?
+
+    exit_page.markdown_cy = markdown_cy
+    exit_page.heading_cy = heading_cy
+
+    exit_page.save!
+  end
+
+  def assign_exit_page_values
+    return self unless exit_page
+
+    self.markdown_cy = exit_page.markdown_cy
+    self.heading_cy = exit_page.heading_cy
+
+    self
+  end
+
+  def form_field_id(attribute)
+    field_id(:forms_welsh_exit_page_translation_input, exit_page.id, :exit_page_translations, attribute)
+  end
+
+  def heading_cy_present?
+    if heading_cy.blank?
+      errors.add(:heading_cy, :blank, question_number: page.position, url: "##{form_field_id(:heading_cy)}")
+    end
+  end
+
+  def heading_cy_length
+    return if heading_cy.length <= 250
+
+    errors.add(:heading_cy, :too_long, question_number: page.position, count: 250, url: "##{form_field_id(:heading_cy)}")
+  end
+
+  def markdown_cy_present?
+    if markdown_cy.blank?
+      errors.add(:markdown_cy, :blank, question_number: page.position, url: "##{form_field_id(:markdown_cy)}")
+    end
+  end
+
+  def markdown_cy_length_and_tags
+    markdown_validation = GovukFormsMarkdown.validate(markdown_cy)
+
+    return true if markdown_validation[:errors].empty?
+
+    if markdown_validation[:errors].include?(:too_long)
+      errors.add(:markdown_cy, :too_long, count: "4,999", question_number: page.position, url: "##{form_field_id(:markdown_cy)}")
+    end
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+    if tag_errors.any?
+      errors.add(:markdown_cy, :unsupported_markdown_syntax, question_number: page.position, url: "##{form_field_id(:markdown_cy)}")
+    end
+  end
+
+  def page
+    @page ||= exit_page.question_page
+  end
+
+  def all_fields_empty?
+    attributes.except!("id").values.all?(&:blank?)
+  end
+end

--- a/app/input_objects/forms/welsh_page_translation_input2.rb
+++ b/app/input_objects/forms/welsh_page_translation_input2.rb
@@ -1,0 +1,276 @@
+class Forms::WelshPageTranslationInput2 < BaseInput
+  include TextInputHelper
+  include ActionView::Helpers::FormTagHelper
+  include ActiveModel::Attributes
+
+  attr_accessor :exit_page_translations, :selection_options_cy
+  attr_reader :page
+
+  attribute :id
+  attribute :question_text_cy
+  attribute :hint_text_cy
+  attribute :page_heading_cy
+  attribute :guidance_markdown_cy
+  attribute :none_of_the_above_question_cy
+
+  validate :question_text_cy_present?, on: :mark_complete
+  validate :question_text_cy_length, if: -> { question_text_cy.present? }
+
+  validate :hint_text_cy_present?, on: :mark_complete
+  validate :hint_text_cy_length, if: -> { hint_text_cy.present? }
+
+  validate :page_heading_cy_present?, on: :mark_complete
+  validate :page_heading_cy_length, if: -> { page_heading_cy.present? }
+
+  validate :guidance_markdown_cy_present?, on: :mark_complete
+  validate :guidance_markdown_cy_length_and_tags, if: -> { guidance_markdown_cy.present? }
+
+  validate :none_of_the_above_question_cy_present?, on: :mark_complete
+  validate :none_of_the_above_question_cy_length, if: -> { none_of_the_above_question_cy.present? }
+
+  validate :exit_page_translations_valid?
+  validate :selection_options_valid?
+
+  def initialize(attributes = {})
+    @page = attributes.delete(:page) if attributes.key?(:page)
+    super
+    self.id ||= @page&.id
+    @exit_page_translations ||= []
+    @selection_options_cy ||= []
+  end
+
+  def submit
+    return false if invalid?
+
+    page.question_text_cy = question_text_cy
+    page.hint_text_cy = page_has_hint_text? ? hint_text_cy : nil
+    page.page_heading_cy = page_has_page_heading_and_guidance_markdown? ? page_heading_cy : nil
+    page.guidance_markdown_cy = page_has_page_heading_and_guidance_markdown? ? guidance_markdown_cy : nil
+
+    exit_page_translations.presence&.each(&:submit)
+
+    page.answer_settings_cy = welsh_answer_settings
+
+    if page_has_none_of_the_above_question?
+      page.answer_settings_cy.none_of_the_above_question.question_text = none_of_the_above_question_cy
+    end
+
+    if page_has_selection_options?
+      page.answer_settings_cy.selection_options = DataStructType.new.cast_value(selection_options_cy.map(&:as_selection_option))
+    end
+
+    page.save!
+  end
+
+  def assign_page_values
+    return self unless page
+
+    self.question_text_cy = page.question_text_cy
+    self.hint_text_cy = page.hint_text_cy
+    self.page_heading_cy = page.page_heading_cy
+    self.guidance_markdown_cy = page.guidance_markdown_cy
+    self.none_of_the_above_question_cy = page.answer_settings_cy&.none_of_the_above_question&.question_text
+
+    exit_page_positions = ExitPage.positions_for_page(page)
+
+    self.exit_page_translations = page.exit_pages.map do |exit_page|
+      Forms::WelshExitPageTranslationInput.new(exit_page:, position: exit_page_positions[exit_page.id]).assign_exit_page_values
+    end
+
+    self.selection_options_cy = welsh_answer_settings&.selection_options&.map&.with_index do |selection_option, index|
+      Forms::WelshSelectionOptionTranslationInput.new(selection_option:, page:, id: index).assign_selection_option_values
+    end
+
+    self
+  end
+
+  def exit_page_translations_attributes=(attributes)
+    submitted_exit_page_ids = attributes.values.map { |attrs| attrs["id"] }.compact
+
+    exit_pages_by_id = page.exit_pages.where(id: submitted_exit_page_ids).index_by(&:id)
+    exit_page_positions = ExitPage.positions_for_page(page)
+
+    self.exit_page_translations = attributes.values.map { |exit_page_attrs|
+      exit_page_id = exit_page_attrs["id"].to_i
+      exit_page_position = exit_page_positions[exit_page_id]
+      exit_page_object = exit_pages_by_id[exit_page_id]
+
+      # skip the exit page if it doesn't belong to the page
+      next unless exit_page_object
+
+      Forms::WelshExitPageTranslationInput.new(exit_page_attrs.symbolize_keys.merge(exit_page: exit_page_object, position: exit_page_position))
+    }.compact
+  end
+
+  def selection_options_cy_attributes=(attributes)
+    self.selection_options_cy = attributes.values.map { |selection_option_attrs|
+      # Get the English selection option from the page's answer settings
+      selection_option_index = selection_option_attrs["id"].to_i
+      english_selection_option = page.answer_settings&.selection_options&.[](selection_option_index)
+
+      # Skip if the selection option doesn't exist in the English version
+      next unless english_selection_option
+
+      Forms::WelshSelectionOptionTranslationInput.new(**selection_option_attrs.symbolize_keys, page:, selection_option: english_selection_option)
+    }.compact
+  end
+
+  def form_field_id(attribute)
+    field_id(:forms_welsh_page_translation_input, page.id, :page_translations, attribute)
+  end
+
+  def page_has_hint_text?
+    page.hint_text.present?
+  end
+
+  def page_has_page_heading_and_guidance_markdown?
+    page.page_heading.present? && page.guidance_markdown.present?
+  end
+
+  def page_has_none_of_the_above_question?
+    return false unless page.answer_type == "selection"
+
+    page.answer_settings&.none_of_the_above_question&.question_text.present?
+  end
+
+  def question_text_cy_present?
+    if question_text_cy.blank?
+      errors.add(:question_text_cy, :blank, question_number: page.position, url: "##{form_field_id(:question_text_cy)}")
+    end
+  end
+
+  def question_text_cy_length
+    return if question_text_cy.length <= QuestionTextValidation::QUESTION_TEXT_MAX_LENGTH
+
+    errors.add(:question_text_cy, :too_long, question_number: page.position, count: QuestionTextValidation::QUESTION_TEXT_MAX_LENGTH, url: "##{form_field_id(:question_text_cy)}")
+  end
+
+  def hint_text_cy_present?
+    if page_has_hint_text? && hint_text_cy.blank?
+      errors.add(:hint_text_cy, :blank, question_number: page.position, url: "##{form_field_id(:hint_text_cy)}")
+    end
+  end
+
+  def hint_text_cy_length
+    return if hint_text_cy.length <= 500
+
+    errors.add(:hint_text_cy, :too_long, question_number: page.position, count: 500, url: "##{form_field_id(:hint_text_cy)}")
+  end
+
+  def page_heading_cy_present?
+    if page_has_page_heading_and_guidance_markdown? && page_heading_cy.blank?
+      errors.add(:page_heading_cy, :blank, question_number: page.position, url: "##{form_field_id(:page_heading_cy)}")
+    end
+  end
+
+  def page_heading_cy_length
+    return if page_heading_cy.length <= 250
+
+    errors.add(:page_heading_cy, :too_long, question_number: page.position, count: 250, url: "##{form_field_id(:page_heading_cy)}")
+  end
+
+  def guidance_markdown_cy_present?
+    if page_has_page_heading_and_guidance_markdown? && guidance_markdown_cy.blank?
+      errors.add(:guidance_markdown_cy, :blank, question_number: page.position, url: "##{form_field_id(:guidance_markdown_cy)}")
+    end
+  end
+
+  def guidance_markdown_cy_length_and_tags
+    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown_cy)
+
+    return true if markdown_validation[:errors].empty?
+
+    if markdown_validation[:errors].include?(:too_long)
+      errors.add(:guidance_markdown_cy, :too_long, count: "4,999", question_number: page.position, url: "##{form_field_id(:guidance_markdown_cy)}")
+    end
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+    if tag_errors.any?
+      errors.add(:guidance_markdown_cy, :unsupported_markdown_syntax, question_number: page.position, url: "##{form_field_id(:guidance_markdown_cy)}")
+    end
+  end
+
+  def none_of_the_above_question_cy_present?
+    if page_has_none_of_the_above_question? && none_of_the_above_question_cy.blank?
+      errors.add(:none_of_the_above_question_cy, :blank, question_number: page.position, url: "##{form_field_id(:none_of_the_above_question_cy)}")
+    end
+  end
+
+  def none_of_the_above_question_cy_length
+    return if none_of_the_above_question_cy.length <= 250
+
+    errors.add(:none_of_the_above_question_cy, :too_long, count: 250, question_number: page.position, url: "##{form_field_id(:none_of_the_above_question_cy)}")
+  end
+
+  def form_marked_complete?
+    mark_complete == "true"
+  end
+
+  def exit_page_translations_valid?
+    return if exit_page_translations.nil?
+
+    exit_page_translations.each do |exit_page_translation|
+      exit_page_translation.validate(validation_context)
+
+      errors.merge!(exit_page_translation.errors)
+    end
+  end
+
+  def selection_options_valid?
+    return if selection_options_cy.nil?
+
+    # We check for duplicates here rather than in the
+    # selection_option_translation because here we can see all the selection options at once
+
+    # This is a list of all the selection options, which we'll use to check for duplicates
+    selection_options_without_blanks = selection_options_cy.map(&:name_cy).compact_blank
+
+    # If there are any duplicates, add a single error and link it to the first selection option
+    if selection_options_without_blanks.uniq.count != selection_options_without_blanks.count
+      first_selection_option_id = selection_options_cy.first.form_field_id(:name_cy)
+      errors.add(:selection_options_cy, :uniqueness, duplicate: selection_options_without_blanks.first, question_number: page.position, url: "##{first_selection_option_id}")
+    end
+
+    # Import all the errors from the child objects
+    selection_options_cy.each do |selection_option_translation|
+      selection_option_translation.validate(validation_context)
+
+      selection_option_translation.errors.each do |error|
+        errors.import(error, { attribute: "select_option_#{selection_option_translation.id}_#{error.attribute}".to_sym })
+      end
+    end
+  end
+
+  def page_has_selection_options?
+    page.answer_type == "selection"
+  end
+
+  # We need to normalize the Welsh answer settings to match the English ones.
+  # The only answer settings that need translating are the selection options
+  # We ensure that welsh answer settings are correct by copying the English
+  # ones setting the selection_options using any existing translations we have
+  # and emptying any we don't have.
+  def welsh_answer_settings
+    return nil unless page_has_selection_options?
+
+    answer_settings_cloned = DataStructType.new.cast_value(page.answer_settings.as_json)
+
+    answer_settings_cloned.selection_options.each.with_index do |selection_option, index|
+      selection_option.name = page.answer_settings_cy&.dig("selection_options", index, "name") || ""
+    end
+
+    if answer_settings_cloned.none_of_the_above_question.present?
+      answer_settings_cloned.none_of_the_above_question.question_text = page.answer_settings_cy&.none_of_the_above_question&.question_text || ""
+    end
+
+    answer_settings_cloned
+  end
+
+  def all_fields_empty?
+    attributes.except!("id").values.all?(&:blank?)
+  end
+
+  def blanked?
+    all_fields_empty? && exit_page_translations.all?(&:all_fields_empty?) && selection_options_cy.all?(&:all_fields_empty?)
+  end
+end

--- a/app/input_objects/forms/welsh_translation_input2.rb
+++ b/app/input_objects/forms/welsh_translation_input2.rb
@@ -1,0 +1,180 @@
+class Forms::WelshTranslationInput2 < Forms::MarkCompleteInput
+  include TextInputHelper
+  include ActiveModel::Attributes
+
+  attr_accessor :form, :page_translations
+
+  attribute :mark_complete
+
+  attribute :name_cy
+  attribute :privacy_policy_url_cy
+  attribute :support_email_cy
+  attribute :support_phone_cy
+  attribute :support_url_cy
+  attribute :support_url_text_cy
+  attribute :declaration_markdown_cy
+  attribute :what_happens_next_markdown_cy
+  attribute :payment_url_cy
+
+  validates :name_cy, presence: true, if: -> { marked_complete? }
+  validates :name_cy, length: { maximum: 500 }, if: -> { name_cy.present? }
+
+  validates :privacy_policy_url_cy, presence: true, if: -> { marked_complete? && form.privacy_policy_url.present? }
+  validates :privacy_policy_url_cy, url: true, if: -> { privacy_policy_url_cy.present? }
+  validates :privacy_policy_url_cy, exclusion: { in: %w[https://www.gov.uk/help/privacy-notice] }, if: -> { privacy_policy_url_cy.present? }
+
+  validates :support_email_cy, presence: true, if: -> { marked_complete? && form_has_support_email? }
+  validates :support_email_cy, email_address: true, allowed_email_domain: true, if: -> { support_email_cy.present? }
+
+  validates :support_phone_cy, presence: true, if: -> { marked_complete? && form_has_support_phone? }
+  validates :support_phone_cy, length: { maximum: 500 }, if: -> { support_phone_cy.present? }
+
+  validates :support_url_cy, presence: true, if: -> { marked_complete? && form_has_support_url? }
+  validates :support_url_cy, url: true, length: { maximum: 120 }, if: -> { support_url_cy.present? }
+
+  validates :support_url_text_cy, presence: true, if: -> { marked_complete? && form_has_support_url? }
+  validates :support_url_text_cy, length: { maximum: 120 }, if: -> { support_url_text_cy.present? }
+
+  validates :declaration_markdown_cy, presence: true, if: -> { marked_complete? && form_has_declaration? }
+  validates :declaration_markdown_cy, length: { maximum: 2000 }, if: -> { declaration_markdown_cy.present? }
+
+  validates :what_happens_next_markdown_cy, presence: true, if: -> { marked_complete? && form.what_happens_next_markdown.present? }
+  validates :what_happens_next_markdown_cy, markdown: { allow_headings: false }, if: -> { what_happens_next_markdown_cy.present? }
+
+  validates :payment_url_cy, presence: true, if: -> { marked_complete? && form_has_payment_url? }
+  validates :payment_url_cy, payment_link: true, if: -> { payment_url_cy.present? }
+
+  validate :page_translations_valid
+
+  def initialize(attributes = {})
+    @form = attributes.delete(:form)
+    super
+    @page_translations ||= []
+  end
+
+  def page_translations_attributes=(attributes)
+    # Get all submitted page IDs from the params hash.
+    submitted_page_ids = attributes.values.map { |attrs| attrs["id"] }.compact
+
+    # lookup hash for efficiency
+    pages_by_id = form.pages.where(id: submitted_page_ids).includes(:exit_pages).index_by(&:id)
+
+    self.page_translations = attributes.values.map { |page_attrs|
+      page_id = page_attrs["id"].to_i
+      page_object = pages_by_id[page_id]
+
+      # skip the page if it doesn't belong to the form
+      next unless page_object
+
+      Forms::WelshPageTranslationInput2.new(page_attrs.symbolize_keys.merge(page: page_object))
+    }.compact
+  end
+
+  def submit
+    return false if invalid?
+
+    form.name_cy = name_cy
+    form.declaration_markdown_cy = form_has_declaration? ? declaration_markdown_cy : nil
+    form.payment_url_cy = form_has_payment_url? ? payment_url_cy : nil
+    form.privacy_policy_url_cy = privacy_policy_url_cy
+    form.support_email_cy = form_has_support_email? ? support_email_cy : nil
+    form.support_phone_cy = form_has_support_phone? ? support_phone_cy : nil
+
+    if form_has_support_url?
+      form.support_url_cy = support_url_cy
+      form.support_url_text_cy = support_url_text_cy
+    else
+      form.support_url_cy = nil
+      form.support_url_text_cy = nil
+    end
+
+    form.what_happens_next_markdown_cy = what_happens_next_markdown_cy
+
+    page_translations.presence&.each(&:submit)
+
+    form.welsh_completed = mark_complete
+
+    # We add :cy to the available languages so that the welsh form can be
+    # previewed. This means that if mark_complete is false, welsh form docs
+    # will be generated.
+    form.available_languages = %w[en cy]
+
+    form.save_draft!
+  end
+
+  def assign_form_values
+    self.name_cy = form.name_cy
+    self.privacy_policy_url_cy = form.privacy_policy_url_cy
+    self.support_email_cy = form.support_email_cy
+    self.support_phone_cy = form.support_phone_cy
+    self.support_url_cy = form.support_url_cy
+    self.support_url_text_cy = form.support_url_text_cy
+    self.declaration_markdown_cy = form.declaration_markdown_cy
+    self.what_happens_next_markdown_cy = form.what_happens_next_markdown_cy
+    self.payment_url_cy = form.payment_url_cy
+
+    self.mark_complete = form.try(:welsh_completed)
+
+    self.page_translations = form.pages.map do |page|
+      Forms::WelshPageTranslationInput2.new(page:).assign_page_values
+    end
+
+    self
+  end
+
+  def blanked?
+    all_fields_empty? && page_translations.all?(&:blanked?)
+  end
+
+  def all_fields_empty?
+    attributes.except!("mark_complete").values.all?(&:blank?)
+  end
+
+  def form_has_declaration?
+    form.declaration_markdown.present?
+  end
+
+  def form_has_payment_url?
+    form.payment_url.present?
+  end
+
+  def form_has_support_url?
+    form.support_url.present?
+  end
+
+  def form_has_support_phone?
+    form.support_phone.present?
+  end
+
+  def form_has_support_email?
+    form.support_email.present?
+  end
+
+  def form_has_support_information?
+    form_has_support_email? || form_has_support_phone? || form_has_support_url?
+  end
+
+  def form_has_what_happens_next?
+    form.what_happens_next_markdown.present?
+  end
+
+  def form_has_privacy_information?
+    form.privacy_policy_url.present?
+  end
+
+  def page_translations_valid
+    return if page_translations.nil?
+
+    # We pass :mark_complete as the validation context so the page_translations
+    # can validate differently depending on whether the form is marked complete
+    validation_context = marked_complete? ? :mark_complete : nil
+
+    page_translations.each do |page_translation|
+      page_translation.validate(validation_context)
+
+      page_translation.errors.each do |error|
+        errors.import(error, { attribute: "page_#{page_translation.page.position}_#{error.attribute}".to_sym })
+      end
+    end
+  end
+end

--- a/app/views/forms/welsh_translation/new.html.erb
+++ b/app/views/forms/welsh_translation/new.html.erb
@@ -151,41 +151,94 @@
               <% end %>
             <% end %>
 
-            <% if page_form.object.condition_translations.present? %>
-              <%= page_form.fields_for :condition_translations, page_form.object.condition_translations do |condition_form| %>
-                <%= condition_form.hidden_field :id %>
-                <% if condition_form.object.condition_has_exit_page? %>
-                  <%= render ScrollingWrapperComponent::View.new(aria_label: t("forms.welsh_translation.new.condition.heading", question_number: page_form.object.page.position)) do %>
+            <% if FeatureService.new(group: @current_form.group).enabled?(:multiple_branches) %>
+              <% if page_form.object.exit_page_translations.present? %>
+                <h3 class="govuk-heading-s">
+                  <%= t("forms.welsh_translation.new.exit_page.page_heading", question_number: page_form.object.page.position, count: page_form.object.exit_page_translations.count) %>
+                </h3>
+                <%= page_form.fields_for :exit_page_translations, page_form.object.exit_page_translations do |exit_page_form| %>
+                  <%= exit_page_form.hidden_field :id %>
+                  <%= render ScrollingWrapperComponent::View.new(aria_label: t("forms.welsh_translation.new.exit_page.page_heading", question_number: page_form.object.page.position, count: page_form.object.exit_page_translations.count)) do %>
                     <%= govuk_table(classes: @table_presenter.three_column_classes) do |table| %>
-                      <%= table.with_caption(size: 's', text: t("forms.welsh_translation.new.condition.heading", question_number: page_form.object.page.position)) %>
+                      <%= table.with_caption(size: 's', text: t("forms.welsh_translation.new.exit_page.name", exit_page_number: exit_page_form.object.position)) %>
                       <%= table.with_head(**@table_presenter.three_column_headers) %>
-
                       <%= table.with_body do |body| %>
                         <%= body.with_row do |row| %>
-                          <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page_heading")) %>
-                          <%= row.with_cell(text: condition_form.object.condition.exit_page_heading, classes: "govuk-!-text-break-word") %>
+                          <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page.heading", exit_page_number: exit_page_form.object.position)) %>
+                          <%= row.with_cell(text: exit_page_form.object.exit_page.heading, classes: "govuk-!-text-break-word") %>
                           <%= row.with_cell do |cell| %>
-                            <%= condition_form.govuk_text_field :exit_page_heading_cy,
-                    id: condition_form.object.form_field_id(:exit_page_heading_cy),
-                    label: { text: t("helpers.label.forms_welsh_condition_translation_input.exit_page_heading_cy_html", question_number: page_form.object.page.position), for: condition_form.object.form_field_id(:exit_page_heading_cy) },
-                    lang: "cy"
-                  %>
+                            <%= exit_page_form.govuk_text_field(
+                              :heading_cy,
+                              id: exit_page_form.object.form_field_id(:heading_cy),
+                              label:  { 
+                                text: t("helpers.label.forms_welsh_exit_page_translation_input.heading_cy_html", exit_page_number: exit_page_form.object.position, question_number: page_form.object.page.position), 
+                                for: exit_page_form.object.form_field_id(:heading_cy),
+                              },
+                              lang: "cy",
+                            )%>
                           <% end %>
                         <% end %>
                         <%= body.with_row do |row| %>
-                          <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page_markdown")) %>
+                          <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page.markdown", exit_page_number: exit_page_form.object.position)) %>
                           <%= row.with_cell(classes: "govuk-!-text-break-word") do %>
-                            <pre class="app-translation-table__markdown-preview"><%= condition_form.object.condition.exit_page_markdown %></pre>
+                            <pre class="app-translation-table__markdown-preview"><%= exit_page_form.object.exit_page.markdown %></pre>
                           <% end %>
                           <%= row.with_cell do |cell| %>
-                            <%= render MarkdownEditorComponent::View.new(:exit_page_markdown_cy,
-                  form_builder: condition_form,
-                  render_preview_path: welsh_translation_render_preview_path(@welsh_translation_input.form.id),
-                  preview_html: nil,
-                  form_model: condition_form.object,
-                  label: t("helpers.label.forms_welsh_condition_translation_input.exit_page_markdown_cy_html", question_number: page_form.object.page.position),
-                  label_heading: false,
-                  lang: "cy") %>
+                            <%= render MarkdownEditorComponent::View.new(
+                                :markdown_cy,
+                                form_builder: exit_page_form,
+                                render_preview_path: welsh_translation_render_preview_path(@welsh_translation_input.form.id),
+                                preview_html: nil,
+                                form_model: exit_page_form.object,
+                                label: t("helpers.label.forms_welsh_exit_page_translation_input.markdown_cy_html", exit_page_number: exit_page_form.object.position, question_number: page_form.object.page.position),
+                                label_heading: false,
+                                lang: "cy"
+                              ) 
+                            %>
+                          <% end %>
+                        <% end %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% else %>
+              <% if page_form.object.condition_translations.present? %>
+                <%= page_form.fields_for :condition_translations, page_form.object.condition_translations do |condition_form| %>
+                  <%= condition_form.hidden_field :id %>
+                  <% if condition_form.object.condition_has_exit_page? %>
+                    <%= render ScrollingWrapperComponent::View.new(aria_label: t("forms.welsh_translation.new.condition.heading", question_number: page_form.object.page.position)) do %>
+                      <%= govuk_table(classes: @table_presenter.three_column_classes) do |table| %>
+                        <%= table.with_caption(size: 's', text: t("forms.welsh_translation.new.condition.heading", question_number: page_form.object.page.position)) %>
+                        <%= table.with_head(**@table_presenter.three_column_headers) %>
+
+                        <%= table.with_body do |body| %>
+                          <%= body.with_row do |row| %>
+                            <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page_heading")) %>
+                            <%= row.with_cell(text: condition_form.object.condition.exit_page_heading, classes: "govuk-!-text-break-word") %>
+                            <%= row.with_cell do |cell| %>
+                              <%= condition_form.govuk_text_field :exit_page_heading_cy,
+                      id: condition_form.object.form_field_id(:exit_page_heading_cy),
+                      label: { text: t("helpers.label.forms_welsh_condition_translation_input.exit_page_heading_cy_html", question_number: page_form.object.page.position), for: condition_form.object.form_field_id(:exit_page_heading_cy) },
+                      lang: "cy"
+                    %>
+                            <% end %>
+                          <% end %>
+                          <%= body.with_row do |row| %>
+                            <%= row.with_cell(header: true, text: t("forms.welsh_translation.new.exit_page_markdown")) %>
+                            <%= row.with_cell(classes: "govuk-!-text-break-word") do %>
+                              <pre class="app-translation-table__markdown-preview"><%= condition_form.object.condition.exit_page_markdown %></pre>
+                            <% end %>
+                            <%= row.with_cell do |cell| %>
+                              <%= render MarkdownEditorComponent::View.new(:exit_page_markdown_cy,
+                    form_builder: condition_form,
+                    render_preview_path: welsh_translation_render_preview_path(@welsh_translation_input.form.id),
+                    preview_html: nil,
+                    form_model: condition_form.object,
+                    label: t("helpers.label.forms_welsh_condition_translation_input.exit_page_markdown_cy_html", question_number: page_form.object.page.position),
+                    label_heading: false,
+                    lang: "cy") %>
+                            <% end %>
                           <% end %>
                         <% end %>
                       <% end %>
@@ -194,7 +247,6 @@
                 <% end %>
               <% end %>
             <% end %>
-
           <% end %>
         <% else %>
           <h2 class="govuk-heading-m"><%= t(".section_headings.pages") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -714,6 +714,13 @@ en:
         csv_download: Download content as CSV
         delete_welsh_version: Delete Welsh version
         english_header: English content
+        exit_page:
+          heading: Exit page %{exit_page_number} heading
+          markdown: Exit page %{exit_page_number} content
+          name: Exit page %{exit_page_number}
+          page_heading:
+            one: Question %{question_number}’s exit page
+            other: Question %{question_number}’s exit pages
         exit_page_heading: Exit page heading
         exit_page_markdown: Exit page content
         guidance_markdown: Guidance text

--- a/config/locales/input_objects/welsh_exit_page_translation.yml
+++ b/config/locales/input_objects/welsh_exit_page_translation.yml
@@ -1,0 +1,22 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        forms/welsh_exit_page_translation_input:
+          attributes:
+            heading_cy:
+              blank: Enter an exit page heading in Welsh for question %{question_number}
+              too_long: The exit page heading for question %{question_number} cannot be longer than %{count} characters
+            markdown_cy:
+              blank: Enter exit page content in Welsh for question %{question_number}
+              too_long: The exit page content for question %{question_number} cannot be longer than %{count} characters
+              unsupported_markdown_syntax: Exit page content for question %{question_number} can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+  helpers:
+    hints:
+      forms_welsh_exit_page_translation_input:
+        markdown_cy: Enter Welsh exit page content
+    label:
+      forms_welsh_exit_page_translation_input:
+        heading_cy_html: Enter Welsh exit page %{exit_page_number} heading<span class="govuk-visually-hidden"> for question %{question_number}</span>
+        markdown_cy_html: Enter Welsh exit page %{exit_page_number} content<span class="govuk-visually-hidden"> for question %{question_number}</span>

--- a/config/locales/input_objects/welsh_exit_page_translation.yml
+++ b/config/locales/input_objects/welsh_exit_page_translation.yml
@@ -18,5 +18,5 @@ en:
         markdown_cy: Enter Welsh exit page content
     label:
       forms_welsh_exit_page_translation_input:
-        heading_cy_html: Enter Welsh exit page %{exit_page_number} heading<span class="govuk-visually-hidden"> for question %{question_number}</span>
-        markdown_cy_html: Enter Welsh exit page %{exit_page_number} content<span class="govuk-visually-hidden"> for question %{question_number}</span>
+        heading_cy_html: Enter <span class="govuk-visually-hidden">question %{question_number}’s</span> Welsh exit page %{exit_page_number} heading
+        markdown_cy_html: Enter <span class="govuk-visually-hidden">question %{question_number}’s</span> Welsh exit page %{exit_page_number} content

--- a/config/locales/input_objects/welsh_page_translation.yml
+++ b/config/locales/input_objects/welsh_page_translation.yml
@@ -23,13 +23,43 @@ en:
               too_long: The question text for question %{question_number} cannot be longer than %{count} characters
             selection_options_cy:
               uniqueness: All of question %{question_number}’s options must be unique
+        forms/welsh_page_translation_input2:
+          attributes:
+            guidance_markdown_cy:
+              blank: Enter guidance text in Welsh for question %{question_number}
+              too_long: The guidance text for question %{question_number} cannot be longer than %{count} characters
+              unsupported_markdown_syntax: Guidance text for question %{question_number} can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+            hint_text_cy:
+              blank: Enter hint text for question %{question_number} in Welsh
+              too_long: The hint text for question %{question_number} cannot be longer than %{count} characters
+            none_of_the_above_question_cy:
+              blank: Enter Welsh question or label if ‘None of the above’ is selected for question %{question_number}
+              too_long: Welsh question or label text for question %{question_number} must be shorter than %{count} characters
+            page_heading_cy:
+              blank: Enter a page heading in Welsh for question %{question_number}
+              too_long: The page heading for question %{question_number} cannot be longer than %{count} characters
+            question_text_cy:
+              blank: Enter question text for question %{question_number} in Welsh
+              too_long: The question text for question %{question_number} cannot be longer than %{count} characters
+            selection_options_cy:
+              uniqueness: All of question %{question_number}’s options must be unique
   helpers:
     hint:
       forms_welsh_page_translation_input:
         guidance_markdown_cy: Enter Welsh guidance text
         what_happens_next_markdown_cy: Enter information about what happens next in Welsh
+      forms_welsh_page_translation_input2:
+        guidance_markdown_cy: Enter Welsh guidance text
+        what_happens_next_markdown_cy: Enter information about what happens next in Welsh
     label:
       forms_welsh_page_translation_input:
+        guidance_markdown_cy_html: Enter Welsh guidance text <span class="govuk-visually-hidden">for question %{question_number}</span>
+        hint_text_cy_html: Enter Welsh hint text <span class="govuk-visually-hidden">for question %{question_number}</span>
+        none_of_the_above_question_cy_html: Enter Welsh question or label if ‘None of the above’ is selected <span class="govuk-visually-hidden">for question %{question_number}</span>
+        page_heading_cy_html: Enter Welsh page heading <span class="govuk-visually-hidden">for question %{question_number}</span>
+        question_text_cy_html: Enter Welsh question text <span class="govuk-visually-hidden">for question %{question_number}</span>
+        selection_options_cy_html: Enter Welsh option %{option_number} <span class="govuk-visually-hidden">for question %{question_number}</span>
+      forms_welsh_page_translation_input2:
         guidance_markdown_cy_html: Enter Welsh guidance text <span class="govuk-visually-hidden">for question %{question_number}</span>
         hint_text_cy_html: Enter Welsh hint text <span class="govuk-visually-hidden">for question %{question_number}</span>
         none_of_the_above_question_cy_html: Enter Welsh question or label if ‘None of the above’ is selected <span class="govuk-visually-hidden">for question %{question_number}</span>

--- a/config/locales/input_objects/welsh_translation.yml
+++ b/config/locales/input_objects/welsh_translation.yml
@@ -38,9 +38,54 @@ en:
               blank: Enter information about what happens next in Welsh
               too_long: The information about what happens next cannot be longer than 4,999 characters
               unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)
+        forms/welsh_translation_input2:
+          attributes:
+            declaration_markdown_cy:
+              blank: Enter a declaration in Welsh
+              too_long: The declaration cannot be longer than 2,000 characters
+            mark_complete:
+              blank: You must choose an option
+            name_cy:
+              blank: Enter a Welsh form name
+              too_long: The form name cannot be longer than %{count} characters
+            payment_url_cy:
+              blank: Enter a Welsh GOV.UK Pay payment link
+              url: Enter a GOV.UK Pay payment link in the correct format, like https://www.gov.uk/payments/your-payment-link
+            privacy_policy_url_cy:
+              blank: Enter a link to privacy information in Welsh
+              exclusion: https://www.gov.uk/help/privacy-notice is the privacy notice for the GOV.UK website and cannot be used for your form
+              url: Enter a link to Welsh privacy information in the correct format, like https://www.gov.uk/help/privacy-notice
+            support_email_cy:
+              blank: Enter an email address for support
+              invalid_email_address: Enter an email address for support in the correct format, like name@example.com
+              non_government_email: Enter a government email address
+            support_phone_cy:
+              blank: Enter the phone number and opening times for support in Welsh
+              too_long: The phone information for support cannot be longer than 500 characters
+            support_url_cy:
+              blank: Enter an online contact link for Welsh support
+              too_long: The link for support cannot be longer than 120 characters
+              url: Enter a link for support in the correct format, like https://www.gov.uk/contact
+            support_url_text_cy:
+              blank: Enter text to describe the contact link for Welsh support
+              too_long: The text to describe the contact link for support cannot be longer than 120 characters
+            what_happens_next_markdown_cy:
+              blank: Enter information about what happens next in Welsh
+              too_long: The information about what happens next cannot be longer than 4,999 characters
+              unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)
   helpers:
     label:
       forms_welsh_translation_input:
+        declaration_markdown_cy: Enter your Welsh declaration
+        name_cy: Enter your Welsh form name
+        payment_url_cy: Enter Welsh GOV.UK Pay payment link
+        privacy_policy_url_cy: Enter link to your Welsh privacy information
+        support_email_cy: Enter email address for Welsh support
+        support_phone_cy: Enter phone information for Welsh support
+        support_url_cy: Enter an online contact link for Welsh support
+        support_url_text_cy: Enter text to describe the contact link for Welsh support
+        what_happens_next_markdown_cy: Enter information about what happens next in Welsh
+      forms_welsh_translation_input2:
         declaration_markdown_cy: Enter your Welsh declaration
         name_cy: Enter your Welsh form name
         payment_url_cy: Enter Welsh GOV.UK Pay payment link

--- a/spec/input_objects/forms/delete_welsh_translation_input_spec.rb
+++ b/spec/input_objects/forms/delete_welsh_translation_input_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe Forms::DeleteWelshTranslationInput, type: :model do
              exit_page_heading_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn."
     end
 
+    let(:exit_page) do
+      create :exit_page,
+             question_page: page,
+             markdown_cy: "Nid ydych yn gymwys",
+             heading_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn."
+    end
+
     context "when the input is invalid" do
       it "returns false" do
         expect(delete_welsh_translation_input.submit).to be false
@@ -142,6 +149,11 @@ RSpec.describe Forms::DeleteWelshTranslationInput, type: :model do
         it "deletes all of the welsh condition content" do
           expect { delete_welsh_translation_input.submit }.to change { condition.reload.exit_page_markdown_cy }.to(nil)
             .and change { condition.reload.exit_page_heading_cy }.to(nil)
+        end
+
+        it "deletes all of the welsh exit page content" do
+          expect { delete_welsh_translation_input.submit }.to change { exit_page.reload.markdown_cy }.to(nil)
+            .and change { exit_page.reload.heading_cy }.to(nil)
         end
 
         it "resets the available_languages field to only include English" do
@@ -266,6 +278,13 @@ RSpec.describe Forms::DeleteWelshTranslationInput, type: :model do
              exit_page_heading_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn."
     end
 
+    let(:exit_page) do
+      create :exit_page,
+             question_page: page,
+             markdown_cy: "Nid ydych yn gymwys",
+             heading_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn."
+    end
+
     context "when called" do
       it "returns true" do
         expect(delete_welsh_translation_input.submit_without_confirm).to be true
@@ -293,6 +312,11 @@ RSpec.describe Forms::DeleteWelshTranslationInput, type: :model do
       it "deletes all of the welsh condition content" do
         expect { delete_welsh_translation_input.submit_without_confirm }.to change { condition.reload.exit_page_markdown_cy }.to(nil)
           .and change { condition.reload.exit_page_heading_cy }.to(nil)
+      end
+
+      it "deletes all of the welsh exit page content" do
+        expect { delete_welsh_translation_input.submit_without_confirm }.to change { exit_page.reload.markdown_cy }.to(nil)
+          .and change { exit_page.reload.heading_cy }.to(nil)
       end
 
       it "resets the available_languages field to only include English" do

--- a/spec/input_objects/forms/welsh_exit_page_translation_input_spec.rb
+++ b/spec/input_objects/forms/welsh_exit_page_translation_input_spec.rb
@@ -1,0 +1,186 @@
+require "rails_helper"
+
+RSpec.describe Forms::WelshExitPageTranslationInput, type: :model do
+  subject(:welsh_exit_page_translation_input) { described_class.new(new_input_data) }
+
+  let(:exit_page) { create_exit_page }
+  let(:page) { create :page }
+
+  let(:new_input_data) do
+    {
+      exit_page:,
+      position: 1,
+      markdown_cy: "Nid ydych yn gymwys",
+      heading_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn.",
+    }
+  end
+
+  def create_exit_page(attributes = {})
+    default_attributes = {
+      id: 1,
+      question_page: page,
+      markdown: "You are ineligible",
+      heading: "Sorry, you are ineligible for this service.",
+      markdown_cy: "",
+      heading_cy: "",
+    }
+    create(:exit_page, default_attributes.merge(attributes))
+  end
+
+  describe "validations" do
+    context "when the form is marked complete" do
+      let(:validation_context) { :mark_complete }
+
+      context "when the Welsh exit page heading is missing" do
+        let(:new_input_data) { super().merge(heading_cy: nil) }
+
+        it "is not valid" do
+          expect(welsh_exit_page_translation_input).not_to be_valid(validation_context)
+          expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to include "Heading cy #{I18n.t('activemodel.errors.models.forms/welsh_condition_translation_input.attributes.exit_page_heading_cy.blank', question_number: exit_page.question_page.position)}"
+        end
+      end
+
+      context "when the Welsh exit page heading is present" do
+        context "when the Welsh exit page heading is 251 characters or more" do
+          let(:new_input_data) { super().merge(heading_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_exit_page_translation_input).not_to be_valid(validation_context)
+            expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to include "Heading cy #{I18n.t('activemodel.errors.models.forms/welsh_condition_translation_input.attributes.exit_page_heading_cy.too_long', question_number: exit_page.question_page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh exit page heading is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(heading_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_exit_page_translation_input).to be_valid(validation_context)
+            expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh exit page markdown is missing" do
+        let(:new_input_data) { super().merge(markdown_cy: nil) }
+
+        it "is not valid" do
+          expect(welsh_exit_page_translation_input).not_to be_valid(validation_context)
+          expect(welsh_exit_page_translation_input.errors.full_messages_for(:markdown_cy)).to include "Markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_condition_translation_input.attributes.exit_page_markdown_cy.blank', question_number: exit_page.question_page.position)}"
+        end
+      end
+
+      context "when the Welsh exit page markdown is present" do
+        it_behaves_like "a markdown field with headings allowed", :mark_complete do
+          let(:model) { welsh_exit_page_translation_input }
+          let(:attribute) { :markdown_cy }
+        end
+      end
+    end
+
+    context "when the form is not marked complete" do
+      let(:validation_context) { nil }
+
+      context "when the Welsh exit page heading is missing" do
+        let(:new_input_data) { super().merge(heading_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_exit_page_translation_input).to be_valid(validation_context)
+          expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh exit page heading is present" do
+        context "when the Welsh exit page heading is 251 characters or more" do
+          let(:new_input_data) { super().merge(heading_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_exit_page_translation_input).not_to be_valid(validation_context)
+            expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to include "Heading cy #{I18n.t('activemodel.errors.models.forms/welsh_condition_translation_input.attributes.exit_page_heading_cy.too_long', question_number: exit_page.question_page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh exit page heading is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(heading_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_exit_page_translation_input).to be_valid(validation_context)
+            expect(welsh_exit_page_translation_input.errors.full_messages_for(:heading_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh exit page markdown is missing" do
+        let(:new_input_data) { super().merge(markdown_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_exit_page_translation_input).to be_valid(validation_context)
+          expect(welsh_exit_page_translation_input.errors.full_messages_for(:markdown_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh exit page markdown is present" do
+        it_behaves_like "a markdown field with headings allowed", :mark_complete do
+          let(:model) { welsh_exit_page_translation_input }
+          let(:attribute) { :markdown_cy }
+        end
+      end
+    end
+  end
+
+  describe "#submit" do
+    it "returns true" do
+      expect(welsh_exit_page_translation_input.submit).to be true
+    end
+
+    it "updates the exit page's welsh attributes with the new values" do
+      welsh_exit_page_translation_input.submit
+      exit_page.reload
+
+      expect(exit_page.reload.markdown_cy).to eq(new_input_data[:markdown_cy])
+      expect(exit_page.reload.heading_cy).to eq(new_input_data[:heading_cy])
+    end
+
+    it "does not update any non-welsh attributes" do
+      english_value_before = exit_page.markdown
+      welsh_exit_page_translation_input.submit
+      expect(exit_page.reload.markdown).to eq(english_value_before)
+    end
+  end
+
+  describe "#assign_page_values" do
+    it "loads the existing welsh attributes from the page" do
+      welsh_exit_page_translation_input = described_class.new(exit_page:)
+      welsh_exit_page_translation_input.assign_exit_page_values
+
+      expect(welsh_exit_page_translation_input.markdown_cy).to eq(exit_page.markdown_cy)
+      expect(welsh_exit_page_translation_input.heading_cy).to eq(exit_page.heading_cy)
+    end
+  end
+
+  describe "#form_field_id" do
+    let(:exit_page) do
+      create_exit_page(id: 999)
+    end
+
+    it "returns the custom ID for each attribute" do
+      expect(welsh_exit_page_translation_input.form_field_id(:markdown_cy)).to eq "forms_welsh_exit_page_translation_input_#{exit_page.id}_exit_page_translations_markdown_cy"
+      expect(welsh_exit_page_translation_input.form_field_id(:heading_cy)).to eq "forms_welsh_exit_page_translation_input_#{exit_page.id}_exit_page_translations_heading_cy"
+    end
+  end
+
+  describe "#all_fields_empty?" do
+    context "when the welsh exit page fields are not empty" do
+      it "returns false" do
+        expect(welsh_exit_page_translation_input.all_fields_empty?).to be false
+      end
+    end
+
+    context "when the welsh condition fields are all empty" do
+      let(:new_input_data) { { exit_page:, markdown_cy: "", heading_cy: "" } }
+
+      it "returns true" do
+        expect(welsh_exit_page_translation_input.all_fields_empty?).to be true
+      end
+    end
+  end
+end

--- a/spec/input_objects/forms/welsh_page_translation_input2_spec.rb
+++ b/spec/input_objects/forms/welsh_page_translation_input2_spec.rb
@@ -1,0 +1,714 @@
+require "rails_helper"
+
+RSpec.describe Forms::WelshPageTranslationInput2, type: :model do
+  subject(:welsh_page_translation_input) { described_class.new(new_input_data) }
+
+  let(:page) { create_page }
+
+  let(:exit_page) do
+    create :exit_page, question_page: page,
+                       heading: "You are ineligible",
+                       markdown: "Sorry, you are ineligible for this service."
+  end
+
+  let(:another_exit_page) do
+    create :exit_page, question_page: page,
+                       heading: "Exit page heading",
+                       markdown: "Exit page markdown"
+  end
+
+  let(:new_input_data) do
+    {
+      page:,
+      question_text_cy: "Ydych chi'n adnewyddu trwydded?",
+      hint_text_cy: "Dewiswch 'Ydw' os oes gennych drwydded ddilys eisoes.",
+      page_heading_cy: "Trwyddedu",
+      guidance_markdown_cy: "Mae'r rhan hon o'r ffurflen yn ymwneud â thrwyddedu.",
+    }
+  end
+
+  def create_page(attributes = {})
+    default_attributes = {
+      id: 1,
+      question_text: "Are you renewing a licence?",
+      hint_text: "Choose 'Yes' if you already have a valid licence.",
+      page_heading: "Licencing",
+      guidance_markdown: "This part of the form concerns licencing.",
+      question_text_cy: "",
+      hint_text_cy: "",
+      page_heading_cy: "",
+      guidance_markdown_cy: "",
+    }
+    create(:page, default_attributes.merge(attributes))
+  end
+
+  describe "validations" do
+    context "when the form is marked complete" do
+      context "when the Welsh question text is missing" do
+        let(:new_input_data) { super().merge(question_text_cy: nil) }
+
+        it "is not valid" do
+          expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+          expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to include "Question text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.question_text_cy.blank', question_number: page.position)}"
+        end
+      end
+
+      context "when the Welsh question text is present" do
+        context "when the Welsh question text is 251 characters or more" do
+          let(:new_input_data) { super().merge(question_text_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to include "Question text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.question_text_cy.too_long', question_number: page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh question text is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(question_text_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh hint text is missing" do
+        let(:new_input_data) { super().merge(hint_text_cy: nil) }
+
+        context "when the form has hint text in English" do
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to include "Hint text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.hint_text_cy.blank', question_number: page.position)}"
+          end
+        end
+
+        context "when the form does not have hint text in English" do
+          let(:page) { create_page(hint_text: nil) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh hint text is present" do
+        context "when the Welsh hint text is 501 characters or more" do
+          let(:new_input_data) { super().merge(hint_text_cy: "a" * 501) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to include "Hint text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.hint_text_cy.too_long', question_number: page.position, count: 500)}"
+          end
+        end
+
+        context "when the Welsh hint text is 500 characters or fewer" do
+          let(:new_input_data) { super().merge(hint_text_cy: "a" * 500) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh page heading is missing" do
+        let(:new_input_data) { super().merge(page_heading_cy: nil) }
+
+        context "when the form has guidance markdown in English" do
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to include "Page heading cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.page_heading_cy.blank', question_number: page.position)}"
+          end
+        end
+
+        context "when the form does not have guidance markdown in English" do
+          let(:page) { create_page(page_heading: nil, guidance_markdown: nil) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh page heading is present" do
+        context "when the Welsh page heading is 251 characters or more" do
+          let(:new_input_data) { super().merge(page_heading_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to include "Page heading cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.page_heading_cy.too_long', question_number: page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh page heading is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(page_heading_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh guidance markdown is missing" do
+        let(:new_input_data) { super().merge(guidance_markdown_cy: nil) }
+
+        context "when the form has guidance markdown in English" do
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:guidance_markdown_cy)).to include "Guidance markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.guidance_markdown_cy.blank', question_number: page.position)}"
+          end
+        end
+
+        context "when the form does not have guidance markdown in English" do
+          let(:page) { create_page(page_heading: nil, guidance_markdown: nil) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:guidance_markdown_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh guidance markdown is present" do
+        it_behaves_like "a markdown field with headings allowed", :mark_complete do
+          let(:model) { welsh_page_translation_input }
+          let(:attribute) { :guidance_markdown_cy }
+        end
+      end
+
+      context "when it's a none of the above question" do
+        let(:page) do
+          create_page(attributes_for(:page, :selection_with_none_of_the_above_question))
+        end
+        let(:new_input_data) do
+          super().merge({
+            none_of_the_above_question_cy: "Welsh none of the above question?",
+            selection_options_cy_attributes: {
+              "0" => { "id" => "0", "name_cy" => "First" },
+              "1" => { "id" => "1", "name_cy" => "Second" },
+            },
+          })
+        end
+
+        context "when the none of the above question is present" do
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:none_of_the_above_question_cy)).to be_empty
+          end
+        end
+
+        context "when the none of the above question is missing" do
+          let(:new_input_data) { super().merge(none_of_the_above_question_cy: nil) }
+
+          it "is invalid" do
+            expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+            expect(welsh_page_translation_input.errors.full_messages_for(:none_of_the_above_question_cy)).to include "None of the above question cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.none_of_the_above_question_cy.blank', question_number: page.position)}"
+          end
+        end
+      end
+    end
+
+    context "when the form is not marked complete" do
+      context "when the Welsh question text is missing" do
+        let(:new_input_data) { super().merge(question_text_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_page_translation_input).to be_valid
+          expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh question text is present" do
+        context "when the Welsh question text is 251 characters or more" do
+          let(:new_input_data) { super().merge(question_text_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to include "Question text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.question_text_cy.too_long', question_number: page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh question text is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(question_text_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:question_text_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh hint text is missing" do
+        let(:new_input_data) { super().merge(hint_text_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_page_translation_input).to be_valid
+          expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh hint text is present" do
+        context "when the Welsh hint text is 501 characters or more" do
+          let(:new_input_data) { super().merge(hint_text_cy: "a" * 501) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to include "Hint text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.hint_text_cy.too_long', question_number: page.position, count: 500)}"
+          end
+        end
+
+        context "when the Welsh hint text is 500 characters or fewer" do
+          let(:new_input_data) { super().merge(hint_text_cy: "a" * 500) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:hint_text_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh page heading is missing" do
+        let(:new_input_data) { super().merge(page_heading_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_page_translation_input).to be_valid
+          expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh page heading is present" do
+        context "when the Welsh page heading is 251 characters or more" do
+          let(:new_input_data) { super().merge(page_heading_cy: "a" * 251) }
+
+          it "is not valid" do
+            expect(welsh_page_translation_input).not_to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to include "Page heading cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.page_heading_cy.too_long', question_number: page.position, count: 250)}"
+          end
+        end
+
+        context "when the Welsh page heading is 250 characters or fewer" do
+          let(:new_input_data) { super().merge(page_heading_cy: "a" * 250) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:page_heading_cy)).to be_empty
+          end
+        end
+      end
+
+      context "when the Welsh guidance markdown is missing" do
+        let(:new_input_data) { super().merge(guidance_markdown_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_page_translation_input).to be_valid
+          expect(welsh_page_translation_input.errors.full_messages_for(:guidance_markdown_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh guidance markdown is present" do
+        it_behaves_like "a markdown field with headings allowed", :mark_complete do
+          let(:model) { welsh_page_translation_input }
+          let(:attribute) { :guidance_markdown_cy }
+        end
+      end
+
+      context "when the page has repeated selection options" do
+        let(:page) do
+          create_page(answer_type: "selection",
+                      answer_settings: { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] })
+        end
+        let(:new_input_data) do
+          super().merge({ selection_options_cy_attributes: {
+            "0" => { "id" => "0", "name_cy" => "same" },
+            "1" => { "id" => "1", "name_cy" => "same" },
+          } })
+        end
+
+        it "is invalid" do
+          expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+          expect(welsh_page_translation_input.errors.full_messages_for(:selection_options_cy)).to include "Selection options cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.selection_options_cy.uniqueness', question_number: page.position)}"
+        end
+      end
+
+      context "when it's a none of the above question" do
+        let(:page) do
+          create_page(attributes_for(:page, :selection_with_none_of_the_above_question))
+        end
+        let(:new_input_data) do
+          super().merge({
+            none_of_the_above_question_cy: "Welsh none of the above question?",
+            selection_options_cy_attributes: {
+              "0" => { "id" => "0", "name_cy" => "First" },
+              "1" => { "id" => "1", "name_cy" => "Second" },
+            },
+          })
+        end
+
+        context "when the none of the above question is missing" do
+          let(:new_input_data) { super().merge(none_of_the_above_question_cy: nil) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid
+          end
+        end
+
+        context "when the none of the above question is shorter than 250 characters" do
+          let(:new_input_data) { super().merge(none_of_the_above_question_cy: "a" * 249) }
+
+          it "is valid" do
+            expect(welsh_page_translation_input).to be_valid
+          end
+        end
+
+        context "when the none of the above question is longer than 250 characters" do
+          let(:new_input_data) { super().merge(none_of_the_above_question_cy: "a" * 251) }
+
+          it "is invalid" do
+            expect(welsh_page_translation_input).not_to be_valid
+            expect(welsh_page_translation_input.errors.full_messages_for(:none_of_the_above_question_cy)).to include "None of the above question cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.none_of_the_above_question_cy.too_long', count: 250, question_number: page.position)}"
+          end
+        end
+      end
+    end
+
+    context "when any of the page's exit_page translations have errors" do
+      let(:exit_page_translation) { Forms::WelshExitPageTranslationInput.new(exit_page:) }
+      let(:new_input_data) { super().merge(exit_page_translations: [exit_page_translation]) }
+
+      it "is invalid" do
+        expect(welsh_page_translation_input).not_to be_valid(:mark_complete)
+        expect(welsh_page_translation_input.errors.full_messages_for(:markdown_cy)).to include "Markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_exit_page_translation_input.attributes.markdown_cy.blank', question_number: page.position)}"
+      end
+    end
+  end
+
+  describe "#submit" do
+    it "returns true" do
+      expect(welsh_page_translation_input.submit).to be true
+    end
+
+    it "updates the page's welsh attributes with the new values" do
+      welsh_page_translation_input.submit
+      page.reload
+
+      expect(page.reload.question_text_cy).to eq(new_input_data[:question_text_cy])
+      expect(page.reload.hint_text_cy).to eq(new_input_data[:hint_text_cy])
+      expect(page.reload.page_heading_cy).to eq(new_input_data[:page_heading_cy])
+      expect(page.reload.guidance_markdown_cy).to eq(new_input_data[:guidance_markdown_cy])
+    end
+
+    it "does not update any non-welsh attributes" do
+      english_value_before = page.question_text
+      welsh_page_translation_input.submit
+      expect(page.question_text).to eq(english_value_before)
+    end
+
+    context "when the page has no hint text" do
+      let(:page) { create_page(hint_text: nil) }
+
+      it "clears the Welsh hint text" do
+        welsh_page_translation_input.submit
+        expect(page.reload.hint_text_cy).to be_nil
+      end
+    end
+
+    context "when the page has no page heading or guidance markdown" do
+      let(:page) { create_page(page_heading: nil, guidance_markdown: nil) }
+
+      it "clears the Welsh page heading" do
+        welsh_page_translation_input.submit
+        expect(page.page_heading_cy).to be_nil
+        expect(page.guidance_markdown_cy).to be_nil
+      end
+    end
+
+    context "when the form includes exit page translation objects" do
+      let(:exit_page_translation) { Forms::WelshExitPageTranslationInput.new(exit_page:, heading_cy: "Nid ydych yn gymwys", markdown_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn.") }
+      let(:another_exit_page_translation) { Forms::WelshExitPageTranslationInput.new(exit_page: another_exit_page, heading_cy: "Welsh exit page heading", markdown_cy: "Welsh exit page markdown") }
+
+      let(:new_input_data) { super().merge(exit_page_translations: [exit_page_translation, another_exit_page_translation]) }
+
+      it "submits the data on the exit page translation objects" do
+        welsh_page_translation_input.submit
+
+        expect(exit_page.reload.heading_cy).to eq("Nid ydych yn gymwys")
+        expect(exit_page.reload.markdown_cy).to eq("Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn.")
+        expect(another_exit_page.reload.heading_cy).to eq("Welsh exit page heading")
+        expect(another_exit_page.reload.markdown_cy).to eq("Welsh exit page markdown")
+      end
+    end
+
+    context "when the page has selection options" do
+      let(:page) do
+        create_page(answer_type: "selection",
+                    answer_settings: { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] })
+      end
+      let(:new_input_data) do
+        super().merge({ selection_options_cy_attributes: {
+          "0" => { "id" => "0", "name_cy" => "welsh option 1" },
+          "1" => { "id" => "1", "name_cy" => "welsh option 2" },
+        } })
+      end
+
+      it "submits the data on the selection options" do
+        welsh_page_translation_input.submit
+
+        expect(page.reload.answer_settings_cy.selection_options.count).to eq(2)
+        expect(page.reload.answer_settings_cy.selection_options.first.name).to eq("welsh option 1")
+        expect(page.reload.answer_settings_cy.selection_options.first.value).to eq("Option 1")
+
+        expect(page.reload.answer_settings_cy.selection_options.second.name).to eq("welsh option 2")
+        expect(page.reload.answer_settings_cy.selection_options.second.value).to eq("Option 2")
+      end
+    end
+
+    context "when the page has a selection question with none of the above" do
+      let(:page) do
+        create_page(attributes_for(:page, :selection_with_none_of_the_above_question))
+      end
+
+      let(:new_input_data) do
+        super().merge({ none_of_the_above_question_cy: "Welsh none of the above question?" })
+      end
+
+      it "assigns the welsh none of the above question text" do
+        welsh_page_translation_input.submit
+
+        expect(page.answer_settings_cy.none_of_the_above_question.question_text).to eq("Welsh none of the above question?")
+      end
+    end
+  end
+
+  describe "#assign_page_values" do
+    it "loads the existing welsh attributes from the page" do
+      welsh_page_translation_input = described_class.new(id: page.id)
+      welsh_page_translation_input.assign_page_values
+
+      expect(welsh_page_translation_input.question_text_cy).to eq(page.question_text_cy)
+      expect(welsh_page_translation_input.hint_text_cy).to eq(page.hint_text_cy)
+      expect(welsh_page_translation_input.page_heading_cy).to eq(page.page_heading_cy)
+      expect(welsh_page_translation_input.guidance_markdown_cy).to eq(page.guidance_markdown_cy)
+    end
+
+    context "when the page has selection options" do
+      let(:page) do
+        create_page(answer_type: "selection",
+                    answer_settings: { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] })
+      end
+
+      it "sets the welsh names to empty and keeps values" do
+        welsh_page_translation_input.assign_page_values
+
+        selection_options_cy = welsh_page_translation_input.selection_options_cy.map(&:as_selection_option)
+        expect(selection_options_cy.count).to eq(2)
+        expect(selection_options_cy).to eq([
+          { name: "", value: "Option 1" },
+          { name: "", value: "Option 2" },
+        ])
+      end
+    end
+
+    context "when the page has selection options and existing Welsh options" do
+      let(:page) do
+        create_page(answer_type: "selection",
+                    answer_settings: { only_one_option: "true", selection_options: [{ name: "New value 1", value: "New value 1" }, { name: "New value 2", value: "New value 2" }] },
+                    answer_settings_cy: { only_one_option: "true", selection_options: [{ name: "Welsh option 1", value: "Old value 1" }, { name: "Welsh option 2", value: "Old value 2" }] })
+      end
+
+      it "keeps the welsh text but updates the new values" do
+        welsh_page_translation_input.assign_page_values
+
+        selection_options_cy = welsh_page_translation_input.selection_options_cy.map(&:as_selection_option)
+        expect(selection_options_cy.count).to eq(2)
+        expect(selection_options_cy).to eq([
+          { name: "Welsh option 1", value: "New value 1" },
+          { name: "Welsh option 2", value: "New value 2" },
+        ])
+      end
+    end
+
+    context "when the page has selection options and partial Welsh options" do
+      let(:page) do
+        create_page(answer_type: "selection",
+                    answer_settings: { only_one_option: "true", selection_options: [{ name: "Yes", value: "Yes" }, { name: "No", value: "No" }, { name: "Maybe", value: "Maybe" }] },
+                    answer_settings_cy: { only_one_option: "true", selection_options: [{ name: "Welsh option 1", value: "Yes" }, { name: "", value: "Option 2" }] })
+      end
+
+      it "keeps the welsh text and adds blanks for missing values" do
+        welsh_page_translation_input.assign_page_values
+
+        selection_options_cy = welsh_page_translation_input.selection_options_cy.map(&:as_selection_option)
+
+        expect(selection_options_cy).to eq([
+          { name: "Welsh option 1", value: "Yes" },
+          { name:  "", value: "No" },
+          { name:  "", value: "Maybe" },
+        ])
+      end
+    end
+
+    context "when the page has a selection question with none of the above" do
+      let(:page) do
+        create_page(attributes_for(:page, :selection_with_none_of_the_above_question))
+      end
+
+      it "none_of_the_above_question_cy is nil" do
+        welsh_page_translation_input.assign_page_values
+        expect(welsh_page_translation_input.none_of_the_above_question_cy).to be_nil
+      end
+
+      context "when the welsh none of the above question is present" do
+        let(:page) do
+          create_page(attributes_for(:page,
+                                     :selection_with_none_of_the_above_question,
+                                     answer_settings_cy: {
+                                       selection_options: [
+                                         { name: "Welsh option 1", value: "Option 1" },
+                                         { name: "Welsh option 2", value: "Option 2" },
+                                       ],
+                                       none_of_the_above_question: {
+                                         question_text: "Welsh none of the above question?",
+                                         is_optional: "true",
+                                       },
+                                     }))
+        end
+
+        it "none_of_the_above_question_cy is the welsh text" do
+          welsh_page_translation_input.assign_page_values
+          expect(welsh_page_translation_input.none_of_the_above_question_cy).to eq("Welsh none of the above question?")
+        end
+      end
+    end
+  end
+
+  describe "#page_has_hint_text?" do
+    context "when the page has hint_text" do
+      let(:page) { create_page(hint_text: "Choose 'Yes' if you already have a valid licence.") }
+
+      it "returns true" do
+        expect(welsh_page_translation_input.page_has_hint_text?).to be true
+      end
+    end
+
+    context "when the page has no hint_text" do
+      let(:page) { create_page(hint_text: nil) }
+
+      it "returns false" do
+        expect(welsh_page_translation_input.page_has_hint_text?).to be false
+      end
+    end
+  end
+
+  describe "#page_has_page_heading_and_guidance_markdown?" do
+    context "when the page has a page_heading" do
+      let(:page) { create_page(page_heading: "Licencing") }
+
+      it "returns true" do
+        expect(welsh_page_translation_input.page_has_page_heading_and_guidance_markdown?).to be true
+      end
+    end
+
+    context "when the page has no page_heading and guidance_markdown" do
+      let(:page) { create_page(page_heading: nil, guidance_markdown: nil) }
+
+      it "returns false" do
+        expect(welsh_page_translation_input.page_has_page_heading_and_guidance_markdown?).to be false
+      end
+    end
+  end
+
+  describe "#page_has_none_of_the_above_question?" do
+    it "is false" do
+      expect(welsh_page_translation_input.page_has_none_of_the_above_question?).to be false
+    end
+
+    context "when the page has a selection question with none of the above" do
+      let(:page) do
+        create_page(attributes_for(:page, :selection_with_none_of_the_above_question))
+      end
+
+      it "is true" do
+        expect(welsh_page_translation_input.page_has_none_of_the_above_question?).to be true
+      end
+    end
+  end
+
+  describe "#all_fields_empty?" do
+    context "when the welsh page fields are not empty" do
+      it "returns false" do
+        expect(welsh_page_translation_input.all_fields_empty?).to be false
+      end
+    end
+
+    context "when the welsh page fields are all empty" do
+      let(:new_input_data) { { page:, question_text_cy: "", hint_text_cy: "", page_heading_cy: "", guidance_markdown_cy: "" } }
+
+      it "returns true" do
+        expect(welsh_page_translation_input.all_fields_empty?).to be true
+      end
+    end
+  end
+
+  describe "#blanked?" do
+    let(:page) do
+      create_page(answer_type: "selection",
+                  answer_settings: { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] })
+    end
+    let(:new_input_data) do
+      super().merge(
+        question_text_cy: "",
+        hint_text_cy: "",
+        page_heading_cy: "",
+        guidance_markdown_cy: "",
+        exit_page_translations: [exit_page_translation],
+        selection_options_cy_attributes: {
+          "0" => { "id" => "0", "name_cy" => "" },
+          "1" => { "id" => "1", "name_cy" => "" },
+        },
+      )
+    end
+    let(:exit_page_translation) { Forms::WelshExitPageTranslationInput.new(exit_page:, heading_cy: "", markdown_cy: "") }
+    let(:selection_options_cy) { welsh_page_translation_input.selection_options_cy.map(&:as_selection_option) }
+
+    it "returns true when all fields are blank" do
+      expect(welsh_page_translation_input.blanked?).to be true
+    end
+
+    context "when the welsh page fields are not all blank" do
+      let(:new_input_data) { super().merge(question_text_cy: "New question text") }
+
+      it "returns false" do
+        expect(welsh_page_translation_input.blanked?).to be false
+      end
+    end
+
+    context "when the exit page is not blank" do
+      let(:exit_page_translation) { Forms::WelshExitPageTranslationInput.new(exit_page:, heading_cy: "Heading", markdown_cy: "markdown") }
+
+      it "returns false" do
+        expect(welsh_page_translation_input.blanked?).to be false
+      end
+    end
+
+    context "when the selection options are not all blank" do
+      let(:new_input_data) do
+        super().merge(
+          question_text_cy: "New question text",
+          exit_page_translations: [],
+          selection_options_cy_attributes: {
+            "0" => { "id" => "0", "name_cy" => "welsh option 1" },
+            "1" => { "id" => "1", "name_cy" => "" },
+          },
+        )
+      end
+
+      it "returns false" do
+        expect(welsh_page_translation_input.blanked?).to be false
+      end
+    end
+  end
+end

--- a/spec/input_objects/forms/welsh_translation_input2_spec.rb
+++ b/spec/input_objects/forms/welsh_translation_input2_spec.rb
@@ -1,0 +1,747 @@
+require "rails_helper"
+
+RSpec.describe Forms::WelshTranslationInput2, type: :model do
+  subject(:welsh_translation_input) { described_class.new(new_input_data) }
+
+  let(:form) { build_form }
+  let(:page) do
+    create :page,
+           question_text: "Are you renewing a licence?",
+           hint_text: "Choose 'Yes' if you already have a valid licence.",
+           page_heading: "Licencing",
+           guidance_markdown: "This part of the form concerns licencing.",
+           position: 1
+  end
+  let(:another_page) { create :page }
+
+  let(:mark_complete) { "true" }
+
+  let(:new_input_data) do
+    {
+      form:,
+      mark_complete:,
+      name_cy: "New Welsh name",
+      what_happens_next_markdown_cy: "New Welsh what happens next",
+      declaration_markdown_cy: "New Welsh declaration",
+      support_email_cy: "new-welsh-support@example.gov.uk",
+      support_phone_cy: "0800 123 4567",
+      support_url_cy: "https://www.gov.uk/new-welsh-support",
+      support_url_text_cy: "New Welsh Support",
+      privacy_policy_url_cy: "https://www.gov.uk/new-welsh-privacy",
+      payment_url_cy: "https://www.gov.uk/payments/new-welsh-payment-link",
+    }
+  end
+
+  def build_form(attributes = {})
+    default_attributes = {
+      id: 1,
+      name: "Apply for a juggling licence",
+      what_happens_next_markdown: "English what happens next",
+      welsh_completed: false,
+      what_happens_next_markdown_cy: "Welsh what happens next",
+      declaration_markdown: "English declaration",
+      declaration_markdown_cy: "Welsh declaration",
+      support_email: "english-support@example.gov.uk",
+      support_email_cy: "welsh-support@example.gov.uk",
+      support_phone: "01234 987654",
+      support_phone_cy: "01234 567891",
+      support_url_cy: "https://www.gov.uk/welsh-support",
+      support_url: "https://www.gov.uk/english-support",
+      support_url_text_cy: "Welsh Support",
+      support_url_text: "English Support",
+      privacy_policy_url_cy: "https://www.gov.uk/welsh-privacy",
+      payment_url: "https://www.gov.uk/english-payment",
+      payment_url_cy: "https://www.gov.uk/payments/your-welsh-payment-link",
+    }
+    build(:form, :with_group, default_attributes.merge(attributes))
+  end
+
+  def build_empty_welsh_form
+    empty_attributes = {
+      id: 1,
+      name: "Apply for a juggling licence",
+      what_happens_next_markdown: "English what happens next",
+      welsh_completed: false,
+      what_happens_next_markdown_cy: "",
+      declaration_text: "English declaration",
+      declaration_text_cy: "",
+      support_email: "english-support@example.gov.uk",
+      support_email_cy: "",
+      support_phone: "01234 987654",
+      support_phone_cy: "",
+      support_url_cy: "",
+      support_url: "https://www.gov.uk/english-support",
+      support_url_text_cy: "",
+      support_url_text: "English Support",
+      privacy_policy_url_cy: "",
+      payment_url: "https://www.gov.uk/english-payment",
+      payment_url_cy: "",
+    }
+    build(:form, empty_attributes)
+  end
+
+  describe "validations" do
+    it "is not valid if mark complete is blank" do
+      form = OpenStruct.new(welsh_completed: false, name: "Apply for a juggling licence")
+      welsh_translation_input = described_class.new(mark_complete: nil, form:)
+
+      expect(welsh_translation_input).not_to be_valid
+      expect(welsh_translation_input.errors.full_messages_for(:mark_complete)).to include "Mark complete #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.mark_complete.blank')}"
+    end
+
+    context "when the form is marked complete" do
+      let(:mark_complete) { "true" }
+
+      context "when the Welsh form name is present" do
+        context "when the Welsh form name is 500 characters or fewer" do
+          let(:new_input_data) { super().merge(name_cy: "A form".ljust(500, "x")) }
+
+          it "is valid" do
+            expect(welsh_translation_input).to be_valid
+          end
+        end
+
+        context "when the Welsh form name is 501 characters or more" do
+          let(:new_input_data) { super().merge(name_cy: "A form".ljust(501, "x")) }
+
+          it "is not valid" do
+            expect(welsh_translation_input).not_to be_valid
+            expect(welsh_translation_input.errors.full_messages_for(:name_cy)).to include "Name cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.name_cy.too_long', count: 500)}"
+          end
+        end
+      end
+
+      context "when the Welsh form name is missing" do
+        let(:new_input_data) { super().merge(name_cy: nil) }
+
+        it "is not valid when the Welsh form name is missing" do
+          expect(welsh_translation_input).not_to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:name_cy)).to include "Name cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.name_cy.blank')}"
+        end
+      end
+
+      describe "Welsh privacy policy URL" do
+        context "when the Welsh privacy policy URL is present" do
+          context "when the Welsh privacy policy is a valid link" do
+            let(:new_input_data) { super().merge(privacy_policy_url_cy: "https://www.gov.uk/welsh-privacy") }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to be_empty
+            end
+          end
+
+          context "when the Welsh privacy policy is a link to the example" do
+            let(:new_input_data) { super().merge(privacy_policy_url_cy: "https://www.gov.uk/help/privacy-notice") }
+
+            it "is invalid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to include "Privacy policy url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.privacy_policy_url_cy.exclusion')}"
+            end
+          end
+
+          context "when the Welsh privacy policy is not a URL" do
+            let(:new_input_data) { super().merge(privacy_policy_url_cy: "Something that isn't a URL") }
+
+            it "is invalid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to include "Privacy policy url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.privacy_policy_url_cy.url')}"
+            end
+          end
+        end
+
+        context "when the Welsh privacy policy URL is missing" do
+          let(:new_input_data) { super().merge(privacy_policy_url_cy: nil) }
+
+          context "when the form has a privacy policy URL in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to include "Privacy policy url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.privacy_policy_url_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a privacy policy URL in English" do
+            let(:form) { build_form(privacy_policy_url: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to be_empty
+            end
+          end
+        end
+      end
+
+      describe "Welsh support email" do
+        context "when the Welsh support email is present" do
+          it_behaves_like "a field that rejects invalid email addresses" do
+            let(:model) { welsh_translation_input }
+            let(:attribute) { :support_email_cy }
+          end
+
+          context "when the Welsh support email is a valid Government email address" do
+            let(:new_input_data) { super().merge(support_email_cy: "someone@example.gov.uk") }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to be_empty
+            end
+          end
+
+          context "when the Welsh support email is a correctly formatted email address with a non-government domain" do
+            let(:new_input_data) { super().merge(support_email_cy: "someone@example.com") }
+
+            it "is invalid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to include "Support email cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email')}"
+            end
+
+            context "and the organisation has an associated domain matching the email" do
+              before do
+                create :organisation_domain, organisation: form.group.organisation, domain: "example.com"
+              end
+
+              it "is valid" do
+                expect(welsh_translation_input).to be_valid
+              end
+            end
+          end
+        end
+
+        context "when the Welsh support email is missing" do
+          let(:new_input_data) { super().merge(support_email_cy: nil) }
+
+          context "when the form has a support email in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to include "Support email cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a support email in English" do
+            let(:form) { build_form(support_email: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to be_empty
+            end
+          end
+        end
+      end
+
+      describe "Welsh support phone number" do
+        context "when the Welsh support phone number is present" do
+          context "when the Welsh support phone number is 500 characters or fewer" do
+            let(:new_input_data) { super().merge(support_phone_cy: "01632 960051\nOpening hours: 9am-5pm".ljust(500, "x")) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_phone_cy)).to be_empty
+            end
+          end
+
+          context "when the Welsh support phone number is 501 characters or more" do
+            let(:new_input_data) { super().merge(support_phone_cy: "01632 960051\nOpening hours: 9am-5pm".ljust(501, "x")) }
+
+            it "is invalid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_phone_cy)).to include "Support phone cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_phone_cy.too_long')}"
+            end
+          end
+        end
+
+        context "when the Welsh support phone number is missing" do
+          let(:new_input_data) { super().merge(support_phone_cy: nil) }
+
+          context "when the form has a support phone number in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_phone_cy)).to include "Support phone cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_phone_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a support phone number in English" do
+            let(:form) { build_form(support_phone: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_phone_cy)).to be_empty
+            end
+          end
+        end
+      end
+
+      describe "Welsh support link" do
+        context "when the Welsh support link is present" do
+          context "when the link URL is 120 characters or fewer" do
+            let(:new_input_data) { super().merge(support_url_cy: "https://example.org/".ljust(120, "x")) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+            end
+          end
+
+          context "when the link URL is 120 characters or more" do
+            let(:new_input_data) { super().merge(support_url_cy: "https://example.org/".ljust(121, "x")) }
+
+            it "is invalid" do
+              error_message = I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_url_cy.too_long")
+              expect(welsh_translation_input).to be_invalid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_cy)).to include "Support url cy #{error_message}"
+            end
+          end
+
+          context "when the link URL is not in a valid URL format" do
+            let(:new_input_data) { super().merge(support_url_cy: "not a URL") }
+
+            it "link_href is invalid if not a URL" do
+              error_message = I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_url_cy.url")
+              expect(welsh_translation_input).to be_invalid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_cy)).to include "Support url cy #{error_message}"
+            end
+          end
+        end
+
+        context "when the Welsh support url is missing" do
+          let(:new_input_data) { super().merge(support_url_cy: nil) }
+
+          context "when the form has a support url in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_cy)).to include "Support url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_url_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a support_url in English" do
+            let(:form) { build_form(support_url: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_cy)).to be_empty
+            end
+          end
+        end
+
+        context "when the Welsh support link text is present" do
+          context "when the link text is 120 characters or fewer" do
+            let(:new_input_data) { super().merge(support_url_text_cy: "Online contact form".ljust(120, "x")) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+            end
+          end
+
+          context "when the link text is 120 characters or more" do
+            let(:new_input_data) { super().merge(support_url_text_cy: "Online contact form".ljust(121, "x")) }
+
+            it "is invalid" do
+              error_message = I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_url_text_cy.too_long")
+              expect(welsh_translation_input).to be_invalid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_text_cy)).to include "Support url text cy #{error_message}"
+            end
+          end
+        end
+
+        context "when the Welsh support link text is missing" do
+          let(:new_input_data) { super().merge(support_url_text_cy: nil) }
+
+          context "when the form has a support url in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_text_cy)).to include "Support url text cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_url_text_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a support_url in English" do
+            let(:form) { build_form(support_url: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:support_url_text_cy)).to be_empty
+            end
+          end
+        end
+      end
+
+      context "when the Welsh declaration markdown is present" do
+        context "when the Welsh declaration markdown is 2000 characters or fewer" do
+          let(:new_input_data) { super().merge(declaration_markdown_cy: "By submitting this form you’re confirming that, to the best of your knowledge, the answers you’re providing are correct.".ljust(2000, "x")) }
+
+          it "is valid" do
+            expect(welsh_translation_input).to be_valid
+          end
+        end
+
+        context "when the Welsh declaration markdown is 2001 characters or more" do
+          let(:new_input_data) { super().merge(declaration_markdown_cy: "By submitting this form you’re confirming that, to the best of your knowledge, the answers you’re providing are correct.".ljust(2001, "x")) }
+
+          it "is invalid" do
+            expect(welsh_translation_input).not_to be_valid
+            expect(welsh_translation_input.errors.full_messages_for(:declaration_markdown_cy)).to include "Declaration markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.declaration_markdown_cy.too_long')}"
+          end
+        end
+      end
+
+      context "when the Welsh declaration markdown is missing" do
+        let(:new_input_data) { super().merge(declaration_markdown_cy: nil) }
+
+        context "when the form has declaration text in English" do
+          it "is not valid" do
+            expect(welsh_translation_input).not_to be_valid
+            expect(welsh_translation_input.errors.full_messages_for(:declaration_markdown_cy)).to include "Declaration markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.declaration_markdown_cy.blank')}"
+          end
+        end
+
+        context "when the form does not have declaration text in English" do
+          let(:form) { build_form(declaration_markdown: nil) }
+
+          it "is valid" do
+            expect(welsh_translation_input).to be_valid
+            expect(welsh_translation_input.errors.full_messages_for(:declaration_markdown_cy)).to be_empty
+          end
+        end
+      end
+
+      describe "what_happens_next_markdown_cy" do
+        it_behaves_like "a markdown field with headings disallowed" do
+          let(:model) { welsh_translation_input }
+          let(:attribute) { :what_happens_next_markdown_cy }
+        end
+
+        context "when the Welsh what happens next markdown is missing" do
+          let(:new_input_data) { super().merge(what_happens_next_markdown_cy: nil) }
+
+          context "when the form has what_happens_next_markdown in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:what_happens_next_markdown_cy)).to include "What happens next markdown cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.what_happens_next_markdown_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have what_happens_next_markdown in English" do
+            let(:form) { build_form(what_happens_next_markdown: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:what_happens_next_markdown_cy)).to be_empty
+            end
+          end
+        end
+      end
+
+      describe "Welsh payment link" do
+        context "when the Welsh payment URL is present" do
+          it_behaves_like "a payment link validator" do
+            let(:model) { welsh_translation_input }
+            let(:attribute) { :payment_url_cy }
+          end
+
+          context "when the payment link is not a url" do
+            let(:new_input_data) { super().merge(payment_url_cy: "Something that isn't a URL") }
+
+            it "is invalid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:payment_url_cy)).to include "Payment url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.payment_url_cy.url')}"
+            end
+          end
+        end
+
+        context "when the Welsh payment URL is missing" do
+          let(:new_input_data) { super().merge(payment_url_cy: nil) }
+
+          context "when the form has a payment url in English" do
+            it "is not valid" do
+              expect(welsh_translation_input).not_to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:payment_url_cy)).to include "Payment url cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.payment_url_cy.blank')}"
+            end
+          end
+
+          context "when the form does not have a payment_url_cy in English" do
+            let(:form) { build_form(payment_url: nil) }
+
+            it "is valid" do
+              expect(welsh_translation_input).to be_valid
+              expect(welsh_translation_input.errors.full_messages_for(:payment_url_cy)).to be_empty
+            end
+          end
+        end
+      end
+    end
+
+    context "when the form is not marked complete" do
+      let(:mark_complete) { "false" }
+
+      context "when the Welsh form name is missing" do
+        let(:new_input_data) { super().merge(name_cy: nil) }
+
+        it "is not valid when the Welsh form name is missing" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:name_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh privacy_policy_url is missing" do
+        let(:new_input_data) { super().merge(privacy_policy_url_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:privacy_policy_url_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh support email is missing" do
+        let(:new_input_data) { super().merge(support_email_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh support phone number is missing" do
+        let(:new_input_data) { super().merge(support_phone_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:support_phone_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh support url is missing" do
+        let(:new_input_data) { super().merge(support_url_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:support_url_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh support link text is missing" do
+        let(:new_input_data) { super().merge(support_url_text_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:support_url_text_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh declaration text is missing" do
+        let(:new_input_data) { super().merge(declaration_markdown_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:declaration_markdown_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh what happens next markdown is missing" do
+        let(:new_input_data) { super().merge(what_happens_next_markdown_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:what_happens_next_markdown_cy)).to be_empty
+        end
+      end
+
+      context "when the Welsh payment_url_cy is missing" do
+        let(:new_input_data) { super().merge(payment_url_cy: nil) }
+
+        it "is valid" do
+          expect(welsh_translation_input).to be_valid
+          expect(welsh_translation_input.errors.full_messages_for(:payment_url_cy)).to be_empty
+        end
+      end
+    end
+
+    context "when any of the form's page translations have errors" do
+      let(:page_translation) { Forms::WelshPageTranslationInput2.new(page:) }
+      let(:new_input_data) { super().merge(page_translations: [page_translation]) }
+
+      it "includes the page error with a custom attribute" do
+        expect(welsh_translation_input).not_to be_valid(:mark_complete)
+        expect(welsh_translation_input.errors.full_messages_for(:page_1_question_text_cy)).to include "Page 1 question text cy #{I18n.t('activemodel.errors.models.forms/welsh_page_translation_input.attributes.question_text_cy.blank', question_number: page.position)}"
+      end
+    end
+  end
+
+  describe "#submit" do
+    context "when the data is invalid" do
+      let(:new_input_data) { super().merge(mark_complete: nil) }
+
+      it "returns false" do
+        expect(welsh_translation_input.submit).to be false
+      end
+
+      it "does not update the form's attributes" do
+        original_attributes = form.attributes.clone
+        welsh_translation_input.submit
+        expect(form.attributes).to eq(original_attributes)
+      end
+    end
+
+    context "when the data is valid" do
+      it "returns true" do
+        expect(welsh_translation_input.submit).to be true
+      end
+
+      it "updates the form's welsh attributes with the new values" do
+        welsh_translation_input.submit
+
+        expect(form.welsh_completed).to be true
+        expect(form.what_happens_next_markdown_cy).to eq(new_input_data[:what_happens_next_markdown_cy])
+        expect(form.declaration_markdown_cy).to eq(new_input_data[:declaration_markdown_cy])
+        expect(form.support_email_cy).to eq(new_input_data[:support_email_cy])
+        expect(form.support_phone_cy).to eq(new_input_data[:support_phone_cy])
+        expect(form.support_url_cy).to eq(new_input_data[:support_url_cy])
+        expect(form.support_url_text_cy).to eq(new_input_data[:support_url_text_cy])
+        expect(form.privacy_policy_url_cy).to eq(new_input_data[:privacy_policy_url_cy])
+        expect(form.payment_url_cy).to eq(new_input_data[:payment_url_cy])
+      end
+
+      it "does not update any non-welsh attributes" do
+        english_value_before = form.what_happens_next_markdown
+        welsh_translation_input.submit
+        expect(form.what_happens_next_markdown).to eq(english_value_before)
+      end
+
+      it "adds :cy to the avaliable languages" do
+        welsh_translation_input.submit
+        expect(form.available_languages).to include("cy")
+      end
+
+      context "when the form has no declaration markdown" do
+        let(:form) { build_form(declaration_markdown: nil) }
+
+        it "clears the Welsh declaration text" do
+          welsh_translation_input.submit
+          expect(form.declaration_markdown_cy).to be_nil
+        end
+      end
+
+      context "when the form has no payment URL" do
+        let(:form) { build_form(payment_url: nil) }
+
+        it "clears the Welsh payment URL" do
+          welsh_translation_input.submit
+          expect(form.payment_url_cy).to be_nil
+        end
+      end
+
+      context "when the form has no support URL" do
+        let(:form) { build_form(support_url: nil) }
+
+        it "clears the Welsh support URL" do
+          welsh_translation_input.submit
+          expect(form.support_url_cy).to be_nil
+        end
+
+        it "clears the Welsh support URL text" do
+          welsh_translation_input.submit
+          expect(form.support_url_text_cy).to be_nil
+        end
+      end
+
+      context "when the form has no support phone" do
+        let(:form) { build_form(support_phone: nil) }
+
+        it "clears the Welsh support phone" do
+          welsh_translation_input.submit
+          expect(form.support_phone_cy).to be_nil
+        end
+      end
+
+      context "when the form has no support email" do
+        let(:form) { build_form(support_email: nil) }
+
+        it "clears the Welsh support email" do
+          welsh_translation_input.submit
+          expect(form.support_email_cy).to be_nil
+        end
+      end
+
+      context "when the form includes page translation objects" do
+        let(:page_translation) { Forms::WelshPageTranslationInput2.new(page:, question_text_cy: "Ydych chi'n adnewyddu trwydded?", hint_text_cy: "Dewiswch 'Ydw' os oes gennych drwydded ddilys eisoes.", page_heading_cy: "Trwyddedu", guidance_markdown_cy: "Mae'r rhan hon o'r ffurflen yn ymwneud â thrwyddedu.") }
+        let(:another_page_translation) { Forms::WelshPageTranslationInput2.new(page: another_page, question_text_cy: "Ydych chi'n adnewyddu trwydded?") }
+
+        let(:new_input_data) { super().merge(page_translations: [page_translation, another_page_translation]) }
+
+        it "submits the data on the page translation objects" do
+          welsh_translation_input.submit
+
+          expect(page.reload.question_text_cy).to eq("Ydych chi'n adnewyddu trwydded?")
+          expect(page.reload.hint_text_cy).to eq("Dewiswch 'Ydw' os oes gennych drwydded ddilys eisoes.")
+          expect(another_page.reload.question_text_cy).to eq("Ydych chi'n adnewyddu trwydded?")
+        end
+      end
+    end
+  end
+
+  describe "#assign_form_values" do
+    it "loads the existing welsh attributes from the form" do
+      welsh_translation_input = described_class.new(form:)
+      welsh_translation_input.assign_form_values
+
+      expect(welsh_translation_input.what_happens_next_markdown_cy).to eq(form.what_happens_next_markdown_cy)
+      expect(welsh_translation_input.declaration_markdown_cy).to eq(form.declaration_markdown_cy)
+      expect(welsh_translation_input.support_email_cy).to eq(form.support_email_cy)
+      expect(welsh_translation_input.support_phone_cy).to eq(form.support_phone_cy)
+      expect(welsh_translation_input.support_url_cy).to eq(form.support_url_cy)
+      expect(welsh_translation_input.support_url_text_cy).to eq(form.support_url_text_cy)
+      expect(welsh_translation_input.privacy_policy_url_cy).to eq(form.privacy_policy_url_cy)
+      expect(welsh_translation_input.payment_url_cy).to eq(form.payment_url_cy)
+      expect(welsh_translation_input.mark_complete).to eq(form.welsh_completed)
+    end
+  end
+
+  describe "#all_fields_empty?" do
+    context "when the welsh translation fields are not empty" do
+      let(:form) { build_form }
+
+      it "returns false" do
+        expect(welsh_translation_input.all_fields_empty?).to be false
+      end
+    end
+
+    context "when the welsh translation fields are all empty" do
+      let(:form) { build_empty_welsh_form }
+
+      it "returns true" do
+        welsh_translation_input = described_class.new(form:)
+        expect(welsh_translation_input.all_fields_empty?).to be true
+      end
+    end
+  end
+
+  describe "#blanked?" do
+    let(:page_translation) { Forms::WelshPageTranslationInput2.new(page:) }
+    let(:new_input_data) do
+      {
+        form:,
+        mark_complete:,
+        name_cy: "",
+        what_happens_next_markdown_cy: "",
+        declaration_markdown_cy: "",
+        support_email_cy: "",
+        support_phone_cy: "",
+        support_url_cy: "",
+        support_url_text_cy: "",
+        privacy_policy_url_cy: "",
+        payment_url_cy: "",
+        page_translations: [page_translation],
+      }
+    end
+
+    context "when the welsh translation fields are all blank" do
+      it "returns true" do
+        expect(welsh_translation_input.blanked?).to be true
+      end
+    end
+
+    context "when the pages are not all blank" do
+      let(:page_translation) { Forms::WelshPageTranslationInput2.new(page:, question_text_cy: "Some question text") }
+
+      it "returns false" do
+        expect(welsh_translation_input.blanked?).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/forms/welsh_translation_controller_spec.rb
+++ b/spec/requests/forms/welsh_translation_controller_spec.rb
@@ -35,102 +35,19 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
   end
 
   describe "#create" do
-    let(:mark_complete) { "true" }
-    let(:condition_translations_attributes) { { "0" => { "id" => condition.id, exit_page_heading_cy: "Nid ydych yn gymwys", exit_page_markdown_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn." } } }
-    let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "Ydych chi'n adnewyddu trwydded?", condition_translations_attributes: } } }
-    let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", page_translations_attributes: } } }
+    context "when the multiple branches feature is disabled", feature_multiple_branches: false do
+      let(:mark_complete) { "true" }
+      let(:condition_translations_attributes) { { "0" => { "id" => condition.id, exit_page_heading_cy: "Nid ydych yn gymwys", exit_page_markdown_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn." } } }
+      let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "Ydych chi'n adnewyddu trwydded?", condition_translations_attributes: } } }
+      let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", page_translations_attributes: } } }
 
-    context "when 'Yes' is selected" do
-      it "updates the form, pages and conditions" do
-        expect {
-          post(welsh_translation_create_path(id), params:)
-        }.to change { form.reload.welsh_completed }.to(true)
-        .and change { form.pages.first.reload.question_text_cy }.to("Ydych chi'n adnewyddu trwydded?")
-        .and change { condition.reload.exit_page_heading_cy }.to("Nid ydych yn gymwys")
-      end
-
-      it "redirects to the form task list and displays a success banner including text about being marked complete" do
-        post(welsh_translation_create_path(id), params:)
-        expect(response).to redirect_to(form_path(id))
-        expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
-      end
-    end
-
-    context "when 'No' is selected" do
-      let(:mark_complete) { "false" }
-      let(:form) { create(:form, :ready_for_routing, welsh_completed: true) }
-
-      it "updates the form and redirects to the form task list" do
-        expect {
-          post(welsh_translation_create_path(id), params:)
-        }.to change { form.reload.welsh_completed }.to(false)
-      end
-
-      it "redirects to the form and displays a success banner without text about being marked complete" do
-        post(welsh_translation_create_path(id), params:)
-        expect(response).to redirect_to(form_path(id))
-        expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved"))
-      end
-    end
-
-    context "when no value is selected" do
-      let(:mark_complete) { "" }
-
-      it "does not update the form, pages or conditions" do
-        expect {
-          post(welsh_translation_create_path(id), params:)
-        }.to not_change { form.reload.welsh_completed }
-        .and not_change { form.pages.first.reload.question_text_cy }
-        .and(not_change { condition.reload.exit_page_markdown_cy })
-      end
-
-      it "returns a 422, re-renders the page with an error, and does not display a success banner" do
-        post(welsh_translation_create_path(id), params:)
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response).to render_template(:new)
-        expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.mark_complete.blank"))
-        expect(flash).to be_empty
-      end
-    end
-
-    context "when 'Yes' is selected and all fields are empty" do
-      let(:condition_translations_attributes) { { "0" => { "id" => condition.id, exit_page_heading_cy: "", exit_page_markdown_cy: "" } } }
-      let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "", condition_translations_attributes: } } }
-      let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "", privacy_policy_url_cy: "", page_translations_attributes: } } }
-
-      it "deletes the form" do
-        post(welsh_translation_create_path(id), params:)
-        expect(form.pages.first.reload.question_text_cy).to be_nil
-        expect(condition.reload.exit_page_heading_cy).to be_nil
-      end
-
-      it "redirects to the form with a success banner" do
-        post(welsh_translation_create_path(id), params:)
-        expect(response).to redirect_to(form_path(id))
-        expect(flash[:success]).to eq(I18n.t("forms.welsh_translation.destroy.success"))
-      end
-    end
-
-    context "when 'Yes' is selected and support email does not end in '.gov.uk'" do
-      let(:domain) { "ogd.ewxample" }
-      let(:support_email) { Faker::Internet.email(domain:) }
-
-      let(:form) { create(:form, :ready_for_routing, welsh_completed: false, support_email:) }
-      let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", support_email_cy: support_email, page_translations_attributes: } } }
-
-      it "returns a 422, re-renders the page with an error, and does not display a success banner" do
-        post(welsh_translation_create_path(id), params:)
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response).to render_template(:new)
-        expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email"))
-        expect(flash).to be_empty
-      end
-
-      context "and the organisation has an associated domain matching the email" do
-        before do
-          create :organisation_domain, organisation: group.organisation, domain: domain
+      context "when 'Yes' is selected" do
+        it "updates the form, pages and conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to change { form.reload.welsh_completed }.to(true)
+          .and change { form.pages.first.reload.question_text_cy }.to("Ydych chi'n adnewyddu trwydded?")
+          .and change { condition.reload.exit_page_heading_cy }.to("Nid ydych yn gymwys")
         end
 
         it "redirects to the form task list and displays a success banner including text about being marked complete" do
@@ -139,22 +56,233 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
           expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
         end
       end
-    end
 
-    context "when the user is not authorized" do
-      let(:current_user) { build :user }
+      context "when 'No' is selected" do
+        let(:mark_complete) { "false" }
+        let(:form) { create(:form, :ready_for_routing, welsh_completed: true) }
 
-      it "does not update the form, pages or conditions" do
-        expect {
+        it "updates the form and redirects to the form task list" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to change { form.reload.welsh_completed }.to(false)
+        end
+
+        it "redirects to the form and displays a success banner without text about being marked complete" do
           post(welsh_translation_create_path(id), params:)
-        }.to not_change { form.reload.welsh_completed }
-        .and not_change { form.pages.first.reload.question_text_cy }
-        .and(not_change { condition.reload.exit_page_markdown_cy })
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved"))
+        end
       end
 
-      it "returns 403" do
-        post(welsh_translation_create_path(id), params:)
-        expect(response).to have_http_status(:forbidden)
+      context "when no value is selected" do
+        let(:mark_complete) { "" }
+
+        it "does not update the form, pages or conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to not_change { form.reload.welsh_completed }
+          .and not_change { form.pages.first.reload.question_text_cy }
+          .and(not_change { condition.reload.exit_page_markdown_cy })
+        end
+
+        it "returns a 422, re-renders the page with an error, and does not display a success banner" do
+          post(welsh_translation_create_path(id), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template(:new)
+          expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.mark_complete.blank"))
+          expect(flash).to be_empty
+        end
+      end
+
+      context "when 'Yes' is selected and all fields are empty" do
+        let(:condition_translations_attributes) { { "0" => { "id" => condition.id, exit_page_heading_cy: "", exit_page_markdown_cy: "" } } }
+        let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "", condition_translations_attributes: } } }
+        let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "", privacy_policy_url_cy: "", page_translations_attributes: } } }
+
+        it "deletes the form" do
+          post(welsh_translation_create_path(id), params:)
+          expect(form.pages.first.reload.question_text_cy).to be_nil
+          expect(condition.reload.exit_page_heading_cy).to be_nil
+        end
+
+        it "redirects to the form with a success banner" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("forms.welsh_translation.destroy.success"))
+        end
+      end
+
+      context "when 'Yes' is selected and support email does not end in '.gov.uk'" do
+        let(:domain) { "ogd.ewxample" }
+        let(:support_email) { Faker::Internet.email(domain:) }
+
+        let(:form) { create(:form, :ready_for_routing, welsh_completed: false, support_email:) }
+        let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", support_email_cy: support_email, page_translations_attributes: } } }
+
+        it "returns a 422, re-renders the page with an error, and does not display a success banner" do
+          post(welsh_translation_create_path(id), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template(:new)
+          expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email"))
+          expect(flash).to be_empty
+        end
+
+        context "and the organisation has an associated domain matching the email" do
+          before do
+            create :organisation_domain, organisation: group.organisation, domain: domain
+          end
+
+          it "redirects to the form task list and displays a success banner including text about being marked complete" do
+            post(welsh_translation_create_path(id), params:)
+            expect(response).to redirect_to(form_path(id))
+            expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
+          end
+        end
+      end
+
+      context "when the user is not authorized" do
+        let(:current_user) { build :user }
+
+        it "does not update the form, pages or conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to not_change { form.reload.welsh_completed }
+          .and not_change { form.pages.first.reload.question_text_cy }
+          .and(not_change { condition.reload.exit_page_markdown_cy })
+        end
+
+        it "returns 403" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context "when the multiple branches feature is enabled", :feature_multiple_branches do
+      let(:mark_complete) { "true" }
+      let(:exit_page) { create :exit_page, question_page: form.pages.first }
+      let(:exit_page_translations_attributes) { { "0" => { "id" => exit_page.id, heading_cy: "Nid ydych yn gymwys", markdown_cy: "Mae'n ddrwg gennym, nid ydych yn gymwys ar gyfer y gwasanaeth hwn." } } }
+      let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "Ydych chi'n adnewyddu trwydded?", exit_page_translations_attributes: } } }
+      let(:params) { { forms_welsh_translation_input2: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", page_translations_attributes: } } }
+
+      context "when 'Yes' is selected" do
+        it "updates the form, pages and conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to change { form.reload.welsh_completed }.to(true)
+          .and change { form.pages.first.reload.question_text_cy }.to("Ydych chi'n adnewyddu trwydded?")
+          .and change { exit_page.reload.heading_cy }.to("Nid ydych yn gymwys")
+        end
+
+        it "redirects to the form task list and displays a success banner including text about being marked complete" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
+        end
+      end
+
+      context "when 'No' is selected" do
+        let(:mark_complete) { "false" }
+        let(:form) { create(:form, :ready_for_routing, welsh_completed: true) }
+
+        it "updates the form and redirects to the form task list" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to change { form.reload.welsh_completed }.to(false)
+        end
+
+        it "redirects to the form and displays a success banner without text about being marked complete" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved"))
+        end
+      end
+
+      context "when no value is selected" do
+        let(:mark_complete) { "" }
+
+        it "does not update the form, pages or conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to not_change { form.reload.welsh_completed }
+          .and not_change { form.pages.first.reload.question_text_cy }
+          .and(not_change { exit_page.reload.markdown_cy })
+        end
+
+        it "returns a 422, re-renders the page with an error, and does not display a success banner" do
+          post(welsh_translation_create_path(id), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template(:new)
+          expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.mark_complete.blank"))
+          expect(flash).to be_empty
+        end
+      end
+
+      context "when 'Yes' is selected and all fields are empty" do
+        let(:exit_page_translations_attributes) { { "0" => { "id" => exit_page.id, heading_cy: "", markdown_cy: "" } } }
+        let(:page_translations_attributes) { { "0" => { "id" => form.pages.first.id, question_text_cy: "", exit_page_translations_attributes: } } }
+        let(:params) { { forms_welsh_translation_input2: { form:, mark_complete:, name_cy: "", privacy_policy_url_cy: "", page_translations_attributes: } } }
+
+        it "deletes the form" do
+          post(welsh_translation_create_path(id), params:)
+          expect(form.pages.first.reload.question_text_cy).to be_nil
+          expect(exit_page.reload.heading_cy).to be_nil
+        end
+
+        it "redirects to the form with a success banner" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("forms.welsh_translation.destroy.success"))
+        end
+      end
+
+      context "when 'Yes' is selected and support email does not end in '.gov.uk'" do
+        let(:domain) { "ogd.ewxample" }
+        let(:support_email) { Faker::Internet.email(domain:) }
+
+        let(:form) { create(:form, :ready_for_routing, welsh_completed: false, support_email:) }
+        let(:params) { { forms_welsh_translation_input2: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", support_email_cy: support_email, page_translations_attributes: } } }
+
+        it "returns a 422, re-renders the page with an error, and does not display a success banner" do
+          post(welsh_translation_create_path(id), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template(:new)
+          expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email"))
+          expect(flash).to be_empty
+        end
+
+        context "and the organisation has an associated domain matching the email" do
+          before do
+            create :organisation_domain, organisation: group.organisation, domain: domain
+          end
+
+          it "redirects to the form task list and displays a success banner including text about being marked complete" do
+            post(welsh_translation_create_path(id), params:)
+            expect(response).to redirect_to(form_path(id))
+            expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
+          end
+        end
+      end
+
+      context "when the user is not authorized" do
+        let(:current_user) { build :user }
+
+        it "does not update the form, pages or conditions" do
+          expect {
+            post(welsh_translation_create_path(id), params:)
+          }.to not_change { form.reload.welsh_completed }
+          .and not_change { form.pages.first.reload.question_text_cy }
+          .and(not_change { exit_page.reload.markdown_cy })
+        end
+
+        it "returns 403" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end

--- a/spec/views/forms/welsh_translation/new.html.erb_spec.rb
+++ b/spec/views/forms/welsh_translation/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "forms/welsh_translation/new.html.erb" do
+describe "forms/welsh_translation/new.html.erb", feature_multiple_branches: false do
   let(:form) { build_form }
   let(:page) { create :page, position: 1 }
   let(:another_page) { create :page, position: 2 }
@@ -41,6 +41,7 @@ describe "forms/welsh_translation/new.html.erb" do
     allow(view).to receive_messages(welsh_translation_delete_path:, welsh_translation_download_path:)
     allow(form).to receive(:has_welsh_translation?).and_return(has_welsh_translation?)
     assign(:table_presenter, table_presenter)
+    assign(:current_form, form)
   end
 
   context "when the form has no errors" do
@@ -291,6 +292,51 @@ describe "forms/welsh_translation/new.html.erb" do
           expect(rendered).to have_css("td", text: page.answer_settings.selection_options.second["name"])
           expect(rendered).to have_field("Enter Welsh option 2")
         end
+
+        context "when the multiple branches feature is enabled", :feature_multiple_branches do
+          let(:exit_page) { create :exit_page }
+          let(:welsh_exit_page_translation_input) { Forms::WelshExitPageTranslationInput.new(exit_page:, position: 1).assign_exit_page_values }
+          let(:welsh_page_translation_input) { Forms::WelshPageTranslationInput2.new(page:).assign_page_values }
+          let(:another_welsh_page_translation_input) { Forms::WelshPageTranslationInput2.new(page: another_page).assign_page_values }
+          let(:welsh_translation_input) { Forms::WelshTranslationInput2.new(form:, page_translations: [welsh_page_translation_input, another_welsh_page_translation_input]).assign_form_values }
+
+          context "when a page has an exit page" do
+            let(:page) { create :page, position: 1, exit_pages: [exit_page] }
+
+            it "shows the heading for the exit page section" do
+              expect(rendered).to have_css("h3", text: "Question 1’s exit page")
+            end
+
+            it "shows the English and Welsh text for the exit page fields" do
+              expect(rendered).to have_css("td", text: exit_page.heading)
+              expect(rendered).to have_field("Enter Welsh exit page 1 heading for question #{page.position}", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_css("td", text: exit_page.markdown)
+              expect(rendered).to have_field("Enter Welsh exit page 1 content for question #{page.position}", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+            end
+          end
+
+          context "when a page has multiple exit pages" do
+            let(:another_exit_page) { create :exit_page }
+            let(:another_welsh_exit_page_translation_input) { Forms::WelshExitPageTranslationInput.new(exit_page: another_exit_page, position: 2).assign_exit_page_values }
+            let(:page) { create :page, position: 1, exit_pages: [exit_page, another_exit_page] }
+
+            it "shows the heading for the exit page section" do
+              expect(rendered).to have_css("h3", text: "Question 1’s exit pages")
+            end
+
+            it "shows the English and Welsh text for the exit pages’ fields" do
+              expect(rendered).to have_css("td", text: exit_page.heading)
+              expect(rendered).to have_field("Enter Welsh exit page 1 heading for question #{page.position}", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_css("td", text: exit_page.markdown)
+              expect(rendered).to have_field("Enter Welsh exit page 1 content for question #{page.position}", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+
+              expect(rendered).to have_css("td", text: another_exit_page.heading)
+              expect(rendered).to have_field("Enter Welsh exit page 2 heading for question #{page.position}", type: "text", id: another_welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_css("td", text: another_exit_page.markdown)
+              expect(rendered).to have_field("Enter Welsh exit page 2 content for question #{page.position}", type: "textarea", id: another_welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+            end
+          end
+        end
       end
 
       context "when a page has a selection question with none of the above" do
@@ -402,6 +448,40 @@ describe "forms/welsh_translation/new.html.erb" do
     it "adds an inline error message to the invalid field" do
       error_message = "Error: #{I18n.t('activemodel.errors.models.forms/welsh_condition_translation_input.attributes.exit_page_heading_cy.blank', question_number: page.position)}"
       expect(rendered).to have_css(".govuk-error-message", text: error_message)
+    end
+  end
+
+  context "when the multiple branches feature is enabled", :feature_multiple_branches do
+    let(:exit_page) { create :exit_page }
+    let(:welsh_exit_page_translation_input) { Forms::WelshExitPageTranslationInput.new(exit_page:, position: 1).assign_exit_page_values }
+    let(:welsh_page_translation_input) { Forms::WelshPageTranslationInput2.new(page:).assign_page_values }
+    let(:another_welsh_page_translation_input) { Forms::WelshPageTranslationInput2.new(page: another_page).assign_page_values }
+    let(:welsh_translation_input) { Forms::WelshTranslationInput2.new(form:, page_translations: [welsh_page_translation_input, another_welsh_page_translation_input]).assign_form_values }
+    let(:page) { create :page, position: 1, exit_pages: [exit_page] }
+
+    context "when the exit page translation has a validation error" do
+      before do
+        welsh_exit_page_translation_input.heading_cy = nil
+        welsh_translation_input.validate(mark_complete ? :mark_complete : nil)
+
+        assign(:welsh_translation_input, welsh_translation_input)
+        render
+      end
+
+      it "displays an error summary box" do
+        expect(rendered).to have_css(".govuk-error-summary")
+        expect(rendered).to have_css("h2.govuk-error-summary__title", text: "There is a problem")
+      end
+
+      it "links the error summary to the invalid field" do
+        error_message = I18n.t("activemodel.errors.models.forms/welsh_exit_page_translation_input.attributes.heading_cy.blank", question_number: page.position)
+        expect(rendered).to have_link(error_message, href: "#forms_welsh_exit_page_translation_input_#{exit_page.id}_exit_page_translations_heading_cy")
+      end
+
+      it "adds an inline error message to the invalid field" do
+        error_message = "Error: #{I18n.t('activemodel.errors.models.forms/welsh_exit_page_translation_input.attributes.heading_cy.blank', question_number: page.position)}"
+        expect(rendered).to have_css(".govuk-error-message", text: error_message)
+      end
     end
   end
 end

--- a/spec/views/forms/welsh_translation/new.html.erb_spec.rb
+++ b/spec/views/forms/welsh_translation/new.html.erb_spec.rb
@@ -309,9 +309,9 @@ describe "forms/welsh_translation/new.html.erb", feature_multiple_branches: fals
 
             it "shows the English and Welsh text for the exit page fields" do
               expect(rendered).to have_css("td", text: exit_page.heading)
-              expect(rendered).to have_field("Enter Welsh exit page 1 heading for question #{page.position}", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 1 heading", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
               expect(rendered).to have_css("td", text: exit_page.markdown)
-              expect(rendered).to have_field("Enter Welsh exit page 1 content for question #{page.position}", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 1 content", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
             end
           end
 
@@ -326,14 +326,14 @@ describe "forms/welsh_translation/new.html.erb", feature_multiple_branches: fals
 
             it "shows the English and Welsh text for the exit pages’ fields" do
               expect(rendered).to have_css("td", text: exit_page.heading)
-              expect(rendered).to have_field("Enter Welsh exit page 1 heading for question #{page.position}", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 1 heading", type: "text", id: welsh_exit_page_translation_input.form_field_id(:heading_cy))
               expect(rendered).to have_css("td", text: exit_page.markdown)
-              expect(rendered).to have_field("Enter Welsh exit page 1 content for question #{page.position}", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 1 content", type: "textarea", id: welsh_exit_page_translation_input.form_field_id(:markdown_cy))
 
               expect(rendered).to have_css("td", text: another_exit_page.heading)
-              expect(rendered).to have_field("Enter Welsh exit page 2 heading for question #{page.position}", type: "text", id: another_welsh_exit_page_translation_input.form_field_id(:heading_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 2 heading", type: "text", id: another_welsh_exit_page_translation_input.form_field_id(:heading_cy))
               expect(rendered).to have_css("td", text: another_exit_page.markdown)
-              expect(rendered).to have_field("Enter Welsh exit page 2 content for question #{page.position}", type: "textarea", id: another_welsh_exit_page_translation_input.form_field_id(:markdown_cy))
+              expect(rendered).to have_field("Enter question #{page.position}’s Welsh exit page 2 content", type: "textarea", id: another_welsh_exit_page_translation_input.form_field_id(:markdown_cy))
             end
           end
         end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/Qe1U2bBO/3181-change-welsh-translation-feature-to-work-with-multiple-exit-pages

Adds the alternative way to render Exit Pages on the Welsh translations page when the multiple branches feature flag is enabled. This covers the creation/deletion of multiple exit page translations. 

You can also delete the Welsh translation for a form's exit pages, either by removing the translation and saving the change, or deleting the entire Welsh translation for the form. 

For the technical implementation, I've created some parallel input objects, which have a '2' after their name. At some point in the future we'll want to remove the old input objects and collapse these into being the only input objects - but for now this was a lot easier to do, as it meant only checking the feature flag's state on the top level. 

___

#### A single exit page is listed

<img width="1175" height="805" alt="image" src="https://github.com/user-attachments/assets/c42eb647-91b4-44a4-bc57-eeacd4cd2841" />


___
#### Multiple exit pages are listed in sequence, and translations can be added to individual fields independently

<img width="1147" height="1083" alt="image" src="https://github.com/user-attachments/assets/a9acb41d-5787-4b22-a1b0-3befa9f2e5ae" />

___

#### It should show errors when invalid fields are submitted

<img width="1162" height="489" alt="image" src="https://github.com/user-attachments/assets/d2ff834b-bfc5-4093-a782-4bec6c4ee1c1" />



<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
