### PR TITLE
Fix markdown length validation for exit pages

### DIFF
--- a/config/locales/input_objects/exit_pages.yml
+++ b/config/locales/input_objects/exit_pages.yml
@@ -10,7 +10,7 @@ en:
               too_long: Page heading must be %{count} characters or less
             markdown:
               blank: Enter page content
-              too_long: Page content must be 5000 characters or less
+              too_long: Page content must be 4,999 characters or less
               unsupported_markdown_syntax: Page content can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
   helpers:
     hint:

--- a/config/locales/input_objects/exit_pages.yml
+++ b/config/locales/input_objects/exit_pages.yml
@@ -10,7 +10,7 @@ en:
               too_long: Page heading must be %{count} characters or less
             markdown:
               blank: Enter page content
-              too_long: Page content must be %{count} characters or less
+              too_long: Page content must be 5000 characters or less
               unsupported_markdown_syntax: Page content can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
   helpers:
     hint:

--- a/config/locales/input_objects/update_exit_pages.yml
+++ b/config/locales/input_objects/update_exit_pages.yml
@@ -10,7 +10,7 @@ en:
               too_long: Page heading must be %{count} characters or less
             markdown:
               blank: Enter page content
-              too_long: Page content must be 5000 characters or less
+              too_long: Page content must be 4,999 characters or less
               unsupported_markdown_syntax: Page content can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
   helpers:
     hint:

--- a/config/locales/input_objects/update_exit_pages.yml
+++ b/config/locales/input_objects/update_exit_pages.yml
@@ -10,7 +10,7 @@ en:
               too_long: Page heading must be %{count} characters or less
             markdown:
               blank: Enter page content
-              too_long: Page content must be %{count} characters or less
+              too_long: Page content must be 5000 characters or less
               unsupported_markdown_syntax: Page content can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
   helpers:
     hint:


### PR DESCRIPTION
When the char count for the markdown field is too long, the error cannot be displayed because the translations assumed the count field was available.

As the error is checked in the markdown gem and added to the model in the our validator, it doesn't set the count field.

I looked at different ways of making the count available. I don't think it's worth making wider code changes though. Instead, I've hardcoded the 5000 character limit in the translations.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
