### PR TITLE
Update tasks to make merging organisations easier

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -55,13 +55,13 @@ namespace :organisations do
   end
 
   desc "Merge an organisation into another"
-  task :merge, %i[source_organisation_slug target_organisation_slug] => :environment do |task, args|
+  task :merge, %i[source_organisation_slug target_organisation_slug merge_mous] => :environment do |task, args|
     merge_organisations(**args, task:, dry_run: false)
   end
 
   namespace :merge do
     desc "Merge an organisation into another - dry run"
-    task :dry_run, %i[source_organisation_slug target_organisation_slug] => :environment do |task, args|
+    task :dry_run, %i[source_organisation_slug target_organisation_slug merge_mous] => :environment do |task, args|
       merge_organisations(**args, task:, dry_run: true)
     end
   end
@@ -207,14 +207,16 @@ def run_organisation_fetch(dry_run:)
   end
 end
 
-def merge_organisations(task:, source_organisation_slug: nil, target_organisation_slug: nil, dry_run: false)
-  usage = "usage: rails #{task.name}[<source_organisation_slug>, <target_organisation_slug>]"
+def merge_organisations(task:, source_organisation_slug: nil, target_organisation_slug: nil, merge_mous: false, dry_run: false)
+  usage = "usage: rails #{task.name}[<source_organisation_slug>, <target_organisation_slug>, <merge_mous>]"
   abort usage if source_organisation_slug.blank? || target_organisation_slug.blank?
+  abort usage if merge_mous.present? && !merge_mous.in?(%w[true false])
+  merge_mous_boolean = merge_mous == "true"
 
   source_organisation = Organisation.find_by_slug!(source_organisation_slug)
   target_organisation = Organisation.find_by_slug!(target_organisation_slug)
 
-  if source_organisation.mou_signatures.any? != target_organisation.mou_signatures.any?
+  if !merge_mous_boolean && source_organisation.mou_signatures.any? != target_organisation.mou_signatures.any?
     abort "Can not merge organisations, as #{source_organisation.name} #{source_organisation.mou_signatures.any? ? 'has' : 'has not'} signed MOU but #{target_organisation.name} #{target_organisation.mou_signatures.any? ? 'has' : 'has not'}"
   end
 
@@ -226,21 +228,26 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
     users = User.where(organisation: source_organisation)
     groups = Group.where(organisation: source_organisation)
     domains = OrganisationDomain.where(organisation: source_organisation)
+    mou_signatures = MouSignature.where(organisation: source_organisation)
 
     users.lock.load
     domains.lock.load
     groups.lock.load
+    mou_signatures.lock.load
 
     if groups.pluck(:name).to_set.intersect?(Group.where(organisation: target_organisation).pluck(:name))
       abort "Can not merge #{source_organisation.name} into #{target_organisation.name}, as there are some duplicate group names"
     end
 
     if dry_run
-      Rails.logger.info("#{task.name}: Would move #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}")
+      Rails.logger.info("#{task.name}: Would move #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}") unless merge_mous_boolean
+      Rails.logger.info("#{task.name}: Would move #{users.count} users, #{groups.count} groups, #{domains.count} domains and #{mou_signatures.count} MOU signatures from #{source_organisation.name} to #{target_organisation.name}") if merge_mous_boolean
+
       return
     end
 
-    Rails.logger.info("#{task.name}: Moving #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}")
+    Rails.logger.info("#{task.name}: Moving #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}") unless merge_mous_boolean
+    Rails.logger.info("#{task.name}: Moving #{users.count} users, #{groups.count} groups, #{domains.count} domains and #{mou_signatures.count} MOU signatures from #{source_organisation.name} to #{target_organisation.name}") if merge_mous_boolean
 
     users.update_all(organisation_id: target_organisation.id)
     users.touch_all
@@ -248,6 +255,8 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
     groups.touch_all
     domains.update_all(organisation_id: target_organisation.id)
     domains.touch_all
+    mou_signatures.update_all(organisation_id: target_organisation.id)
+    mou_signatures.touch_all
   end
 end
 

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -90,6 +90,30 @@ namespace :organisations do
     end
   end
 
+  desc "Make organisation open"
+  task :open, %i[organisation_slug] => :environment do |task, args|
+    change_organisation_closed_status(**args, closed: false, task:, dry_run: false)
+  end
+
+  namespace :open do
+    desc "Make organisation open - dry run"
+    task :dry_run, %i[organisation_slug] => :environment do |task, args|
+      change_organisation_closed_status(**args, closed: false, task:, dry_run: true)
+    end
+  end
+
+  desc "Make organisation closed"
+  task :close, %i[organisation_slug] => :environment do |task, args|
+    change_organisation_closed_status(**args, closed: true, task:, dry_run: false)
+  end
+
+  namespace :close do
+    desc "Make organisation closed - dry run"
+    task :dry_run, %i[organisation_slug] => :environment do |task, args|
+      change_organisation_closed_status(**args, closed: true, task:, dry_run: true)
+    end
+  end
+
   namespace :domains do
     desc "Add domains to an organisation"
     task :add, %i[organisation_slug domains] => :environment do |_task, args|
@@ -280,6 +304,32 @@ def change_organisation_internal_status(task:, organisation_slug: nil, status: n
     Rails.logger.info("#{task.name}: Making organisation '#{organisation.name}' #{status_string}")
 
     organisation.internal = status
+    organisation.save!
+
+    Rails.logger.info("#{task.name}: Made organisation '#{organisation.name}' #{status_string}")
+  end
+end
+
+def change_organisation_closed_status(task:, organisation_slug: nil, closed: nil, dry_run: false)
+  usage = "usage: rails #{task.name}[<organisation_slug>]"
+  abort usage if organisation_slug.blank?
+
+  status_string = closed ? "closed" : "open"
+
+  organisation = Organisation.find_by_slug(organisation_slug)
+
+  abort "Organisation not found" if organisation.blank?
+  abort "Organisation '#{organisation.name}' is already #{status_string}" if organisation.closed == closed
+
+  ActiveRecord::Base.transaction do
+    if dry_run
+      Rails.logger.info("#{task.name}: Would make organisation '#{organisation.name}' #{status_string}")
+      return
+    end
+
+    Rails.logger.info("#{task.name}: Making organisation '#{organisation.name}' #{status_string}")
+
+    organisation.closed = closed
     organisation.save!
 
     Rails.logger.info("#{task.name}: Made organisation '#{organisation.name}' #{status_string}")

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -225,8 +225,10 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
   ActiveRecord::Base.transaction do
     users = User.where(organisation: source_organisation)
     groups = Group.where(organisation: source_organisation)
+    domains = OrganisationDomain.where(organisation: source_organisation)
 
     users.lock.load
+    domains.lock.load
     groups.lock.load
 
     if groups.pluck(:name).to_set.intersect?(Group.where(organisation: target_organisation).pluck(:name))
@@ -234,16 +236,18 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
     end
 
     if dry_run
-      Rails.logger.info("#{task.name}: Would move #{users.count} users and #{groups.count} groups from #{source_organisation.name} to #{target_organisation.name}")
+      Rails.logger.info("#{task.name}: Would move #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}")
       return
     end
 
-    Rails.logger.info("#{task.name}: Moving #{users.count} users and #{groups.count} groups from #{source_organisation.name} to #{target_organisation.name}")
+    Rails.logger.info("#{task.name}: Moving #{users.count} users, #{groups.count} groups, and #{domains.count} domains from #{source_organisation.name} to #{target_organisation.name}")
 
     users.update_all(organisation_id: target_organisation.id)
     users.touch_all
     groups.update_all(organisation_id: target_organisation.id)
     groups.touch_all
+    domains.update_all(organisation_id: target_organisation.id)
+    domains.touch_all
   end
 end
 

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -171,7 +171,8 @@ RSpec.describe "organisations.rake", type: :task do
 
     context "when old organisation has signed mou but new organisation has not" do
       before do
-        create :mou_signature_for_organisation, organisation: source_org
+        user = create :user, organisation: source_org
+        create :mou_signature_for_organisation, organisation: source_org, user:
       end
 
       let(:invoked_task) do
@@ -182,6 +183,42 @@ RSpec.describe "organisations.rake", type: :task do
       end
 
       include_examples "it does not move users, groups or domains"
+
+      context "when merge_mous is true" do
+        it "moves users from one organisation to another" do
+          create_list :user, 4, organisation: source_org
+
+          expect {
+            task.invoke("old-organisation", "shiny-new-organisation", "true")
+          }.to change(User.where(organisation: target_org), :count).by(5)
+            .and change(User.where(organisation: source_org), :count).from(5).to(0)
+        end
+
+        it "moves groups from one organisation to another" do
+          create_list :group, 5, organisation: source_org
+
+          expect {
+            task.invoke("old-organisation", "shiny-new-organisation", "true")
+          }.to change(Group.where(organisation: target_org), :count).by(5)
+            .and change(Group.where(organisation: source_org), :count).from(5).to(0)
+        end
+
+        it "moves domains from one organisation to another" do
+          create_list :organisation_domain, 5, organisation: source_org
+
+          expect {
+            task.invoke("old-organisation", "shiny-new-organisation", "true")
+          }.to change(OrganisationDomain.where(organisation: target_org), :count).by(5)
+            .and change(OrganisationDomain.where(organisation: source_org), :count).from(5).to(0)
+        end
+
+        it "moves MOU signatures from one organisation to another" do
+          expect {
+            task.invoke("old-organisation", "shiny-new-organisation", "true")
+          }.to change(MouSignature.where(organisation: target_org), :count).by(1)
+            .and change(MouSignature.where(organisation: source_org), :count).from(1).to(0)
+        end
+      end
     end
 
     context "when old organisation and new organisation have groups with the same name" do

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -318,6 +318,74 @@ RSpec.describe "organisations.rake", type: :task do
     end
   end
 
+  describe "organisations:open" do
+    subject(:task) do
+      Rake::Task["organisations:open"]
+    end
+
+    it "sets an organisation's 'closed' flag to false" do
+      test_org = create :organisation, name: "Department for Testing", slug: "dft", closed: true
+      test_org.clear_changes_information
+
+      expect {
+        task.invoke("dft")
+        test_org.reload
+      }
+        .to change(test_org, :closed).from(true).to(false)
+    end
+
+    it "aborts if the organisation is already open" do
+      test_org = create :organisation, name: "Department for Testing", slug: "dft", closed: false
+      test_org.clear_changes_information
+
+      expect { task.invoke("dft") }
+        .to output(/Organisation 'Department for Testing' is already open/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+
+      expect(test_org.previous_changes).to be_empty
+    end
+
+    it "returns an error for non-existent organisations" do
+      expect { task.invoke("dft") }
+        .to output(/not found/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+  end
+
+  describe "organisations:close" do
+    subject(:task) do
+      Rake::Task["organisations:close"]
+    end
+
+    it "sets an organisation's 'closed' flag to true" do
+      test_org = create :organisation, name: "Department for Testing", slug: "dft", closed: false
+      test_org.clear_changes_information
+
+      expect {
+        task.invoke("dft")
+        test_org.reload
+      }
+        .to change(test_org, :closed).from(false).to(true)
+    end
+
+    it "aborts if the organisation is already closed" do
+      test_org = create :organisation, name: "Department for Testing", slug: "dft", closed: true
+      test_org.clear_changes_information
+
+      expect { task.invoke("dft") }
+        .to output(/Organisation 'Department for Testing' is already closed/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+
+      expect(test_org.previous_changes).to be_empty
+    end
+
+    it "returns an error for non-existent organisations" do
+      expect { task.invoke("dft") }
+        .to output(/not found/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+  end
+
   describe "organisations:domains:add" do
     subject(:task) do
       Rake::Task["organisations:domains:add"]

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -116,7 +116,16 @@ RSpec.describe "organisations.rake", type: :task do
         .and change(Group.where(organisation: source_org), :count).from(5).to(0)
     end
 
-    shared_examples "it does not move users or groups" do
+    it "moves domains from one organisation to another" do
+      create_list :organisation_domain, 5, organisation: source_org
+
+      expect {
+        task.invoke("old-organisation", "shiny-new-organisation")
+      }.to change(OrganisationDomain.where(organisation: target_org), :count).by(5)
+        .and change(OrganisationDomain.where(organisation: source_org), :count).from(5).to(0)
+    end
+
+    shared_examples "it does not move users, groups or domains" do
       RSpec::Matchers.define_negated_matcher :not_change, :change
 
       it "does not move users from one organisation to another" do
@@ -136,9 +145,18 @@ RSpec.describe "organisations.rake", type: :task do
         }.to not_change(Group.where(organisation: target_org), :count)
           .and not_change(Group.where(organisation: source_org), :count)
       end
+
+      it "does not move domains from one organisation to another" do
+        create_list :organisation_domain, 5, organisation: source_org
+
+        expect {
+          invoked_task
+        }.to not_change(OrganisationDomain.where(organisation: target_org), :count)
+          .and not_change(OrganisationDomain.where(organisation: source_org), :count)
+      end
     end
 
-    context "when organisation to move users and groups from is not closed" do
+    context "when old organisation is not closed" do
       let!(:source_org) { create :organisation, slug: "old-organisation", closed: false }
 
       let(:invoked_task) do
@@ -148,7 +166,7 @@ RSpec.describe "organisations.rake", type: :task do
           .and output(/Old Organisation is not yet closed/).to_stderr
       end
 
-      include_examples "it does not move users or groups"
+      include_examples "it does not move users, groups or domains"
     end
 
     context "when old organisation has signed mou but new organisation has not" do
@@ -163,7 +181,7 @@ RSpec.describe "organisations.rake", type: :task do
           .and output(/Old Organisation has signed MOU but Shiny New Organisation has not/).to_stderr
       end
 
-      include_examples "it does not move users or groups"
+      include_examples "it does not move users, groups or domains"
     end
 
     context "when old organisation and new organisation have groups with the same name" do
@@ -179,7 +197,7 @@ RSpec.describe "organisations.rake", type: :task do
           .and output(/there are some duplicate group names/).to_stderr
       end
 
-      include_examples "it does not move users or groups"
+      include_examples "it does not move users, groups or domains"
     end
 
     describe ":dry_run" do
@@ -191,7 +209,7 @@ RSpec.describe "organisations.rake", type: :task do
         task.invoke(source_org.slug, target_org.slug)
       end
 
-      include_examples "it does not move users or groups"
+      include_examples "it does not move users, groups or domains"
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Makes a few updates to make merging organisations easier:
- updates the `organisations:merge` task to include moving email domains, which we added to organisations after we originally wrote this task
- adds a new `merge_mous` flag to the `organisations:merge` task, so that we can optionally merge organisations together even if one of them doesn't have an MOU signed (this will be mainly for cases where an organisation that has signed the MOU gets renamed in a Machinery of Government (MoG) change)
- adds new `organisations:open` and `organisations:close` tasks for setting the `closed` status of an organisation manually (this is useful if an organisation is in the middle of a MoG change and both the old organisation and new organisation are still open in the GOV.UK Organisations API - it lets us close the old organisation to stop new users being spread across both organisations).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
