### PR TITLE
Handle shared domains in organisations:merge task

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -251,7 +251,8 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
   ActiveRecord::Base.transaction do
     users = User.where(organisation: source_organisation)
     groups = Group.where(organisation: source_organisation)
-    domains = OrganisationDomain.where(organisation: source_organisation)
+    shared_domains = OrganisationDomain.where(organisation: source_organisation, domain: target_organisation.organisation_domains.pluck(:domain))
+    domains = OrganisationDomain.where(organisation: source_organisation).excluding(shared_domains)
     mou_signatures = MouSignature.where(organisation: source_organisation)
 
     users.lock.load
@@ -277,6 +278,7 @@ def merge_organisations(task:, source_organisation_slug: nil, target_organisatio
     users.touch_all
     groups.update_all(organisation_id: target_organisation.id)
     groups.touch_all
+    shared_domains.delete_all
     domains.update_all(organisation_id: target_organisation.id)
     domains.touch_all
     mou_signatures.update_all(organisation_id: target_organisation.id)

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -125,6 +125,28 @@ RSpec.describe "organisations.rake", type: :task do
         .and change(OrganisationDomain.where(organisation: source_org), :count).from(5).to(0)
     end
 
+    context "when the two organisations contain the same domain" do
+      before do
+        create_list :organisation_domain, 5, organisation: source_org
+        create_list :organisation_domain, 5, organisation: target_org
+        create :organisation_domain, organisation: source_org, domain: "example.gov.uk"
+        create :organisation_domain, organisation: target_org, domain: "example.gov.uk"
+      end
+
+      it "deletes the shared domain from the source organisation" do
+        expect {
+          task.invoke("old-organisation", "shiny-new-organisation")
+        }.to change { OrganisationDomain.exists?(organisation: source_org, domain: "example.gov.uk") }.from(true).to(false)
+      end
+
+      it "moves the other domains from one organisation to another" do
+        expect {
+          task.invoke("old-organisation", "shiny-new-organisation")
+        }.to change(OrganisationDomain.where(organisation: target_org), :count).by(5)
+          .and change(OrganisationDomain.where(organisation: source_org), :count).from(6).to(0)
+      end
+    end
+
     shared_examples "it does not move users, groups or domains" do
       RSpec::Matchers.define_negated_matcher :not_change, :change
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We recently added support for merging email domains as part of this task (as part of #3070). When we ran this in production, we saw a validation error - we expect OrganisationDomains to be unique within an organisation, so when the task tried to move the domain from the source organisation it violated this constraint.

This PR updates the task so that it deletes the duplicate OrganisationDomain instead of trying to move it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
