### PR TITLE
Show existing routes for long selection questions

### DIFF
--- a/app/controllers/pages/exit_pages_controller.rb
+++ b/app/controllers/pages/exit_pages_controller.rb
@@ -91,7 +91,7 @@ private
   end
 
   def check_page_can_have_exit_pages
-    return if Forms::RoutesInput.route_with_selection_options?(page)
+    return if Forms::RoutesInput.can_have_exit_pages?(page)
 
     render "errors/not_found", status: :not_found, formats: :html
   end

--- a/app/input_objects/forms/route_input.rb
+++ b/app/input_objects/forms/route_input.rb
@@ -40,7 +40,7 @@ class Forms::RouteInput < BaseInput
   end
 
   def label_text
-    if Forms::RoutesInput.route_with_selection_options?(page)
+    if selection_options_route?
       answer_value_label = answer_value == Condition::NONE_OF_THE_ABOVE ? I18n.t("page_conditions.none_of_the_above") : answer_value
       return "If option #{option_index} (#{answer_value_label}), go to:"
     end
@@ -49,6 +49,14 @@ class Forms::RouteInput < BaseInput
   end
 
 private
+
+  def generic_route?
+    answer_value.nil?
+  end
+
+  def selection_options_route?
+    !generic_route?
+  end
 
   def route_is_not_backwards
     return if !goes_to_page? || goto_page.nil?
@@ -59,7 +67,7 @@ private
   end
 
   def error_message_for_backwards_route
-    if Forms::RoutesInput.route_with_selection_options?(page)
+    if selection_options_route?
       I18n.t("errors.routes.cannot_route_backwards_from_selection_page", question_number: page.position, option_number: option_index)
     else
       I18n.t("errors.routes.cannot_route_backwards_from_generic_page", question_number: page.position)

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -10,7 +10,11 @@ class Forms::RoutesInput < BaseInput
   end
 
   def self.route_with_selection_options?(page)
-    page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !Forms::RoutesInput.too_many_selection_options?(page)
+    page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !too_many_selection_options?(page)
+  end
+
+  def self.can_have_exit_pages?(page)
+    route_with_selection_options?(page)
   end
 
   def initialize(attributes = {})

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -5,12 +5,20 @@ class Forms::RoutesInput < BaseInput
 
   validate :routes_are_valid
 
-  def self.too_many_selection_options?(page)
-    page.answer_settings["selection_options"].length > 10
+  def self.routes_type(page)
+    if page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !too_many_selection_options?(page)
+      :selection_options_routes
+    else
+      :generic_route
+    end
   end
 
   def self.route_with_selection_options?(page)
-    page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !too_many_selection_options?(page)
+    routes_type(page) == :selection_options_routes
+  end
+
+  def self.too_many_selection_options?(page)
+    page.answer_settings["selection_options"].length > 10
   end
 
   def self.can_have_exit_pages?(page)

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -6,19 +6,34 @@ class Forms::RoutesInput < BaseInput
   validate :routes_are_valid
 
   def self.routes_type(page)
-    if page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !too_many_selection_options?(page)
-      :selection_options_routes
+    if page.answer_type == "selection" && page.answer_settings.only_one_option == "true"
+      if too_many_selection_options?(page)
+        if existing_selection_options_routes?(page)
+          :existing_selection_options_routes
+        else
+          :generic_route
+        end
+      else
+        :selection_options_routes
+      end
     else
       :generic_route
     end
   end
 
   def self.route_with_selection_options?(page)
-    routes_type(page) == :selection_options_routes
+    %i[
+      selection_options_routes
+      existing_selection_options_routes
+    ].include? routes_type(page)
   end
 
   def self.too_many_selection_options?(page)
     page.answer_settings["selection_options"].length > 10
+  end
+
+  def self.existing_selection_options_routes?(page)
+    page.routing_conditions.any? { it.answer_value.present? }
   end
 
   def self.can_have_exit_pages?(page)

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -17,10 +17,14 @@ class Routes::BuildService
     end
 
     form.pages.flat_map do |page|
-      if Forms::RoutesInput.route_with_selection_options?(page)
+      routes_type = Forms::RoutesInput.routes_type(page)
+      case routes_type
+      when :selection_options_routes
         build_routes_for_selection_page(page, conditions_by_key)
-      else
+      when :generic_route
         build_route_for_generic_page(page, conditions_by_key)
+      else
+        raise "Unexpected routes type :#{routes_type}"
       end
     end
   end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -21,6 +21,8 @@ class Routes::BuildService
       case routes_type
       when :selection_options_routes
         build_routes_for_selection_page(page, conditions_by_key)
+      when :existing_selection_options_routes
+        build_routes_for_existing_conditions_for_selection_page(page, conditions_by_key)
       when :generic_route
         build_route_for_generic_page(page, conditions_by_key)
       else
@@ -100,6 +102,30 @@ private
         goto: goto_value_for(condition),
         goto_page: condition&.goto_page,
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
+      )
+    end
+  end
+
+  def build_routes_for_existing_conditions_for_selection_page(page, conditions_by_key)
+    options = page.answer_settings&.selection_options&.dup || []
+
+    options << NONE_OF_THE_ABOVE_OPTION if page.is_optional
+
+    options.filter_map do |option|
+      answer_value = option["value"]
+      key = [page.id, answer_value]
+      condition = conditions_by_key[key]
+
+      next unless condition
+
+      Forms::RouteInput.new(
+        id: condition.id,
+        page_id: page.id,
+        page:,
+        answer_value:,
+        goto: goto_value_for(condition),
+        goto_page: condition.goto_page,
+        goto_options: options_for_goto_page(page, condition.goto_page_id),
       )
     end
   end

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -25,7 +25,7 @@
               row.with_value do
                 capture do %>
                 <p> <%= page.question_text %> </p>
-                <% if @routes_input.form.next_page_after(page).present? || routes.any?(&:invalid?) || @routes_input.class.route_with_selection_options?(page) %>
+                <% if @routes_input.form.next_page_after(page).present? || routes.any?(&:invalid?) || @routes_input.class.can_have_exit_pages?(page) %>
                   <ul class="govuk-list">
                     <% routes.each do |route| %>
                       <li>
@@ -49,7 +49,7 @@
                             @routes_input.class.too_many_selection_options?(page) %>
                     <%= t(".too_many_options_html") %>
                   <% end %>
-                  <% if Forms::RoutesInput::route_with_selection_options?(page) %>
+                  <% if Forms::RoutesInput::can_have_exit_pages?(page) %>
                     <%= f.govuk_submit t(".add_exit_page_html", question_number: page.position), secondary: true, name: 'new_exit_page', value: page.id, class: page.exit_pages.any? ? "" : "govuk-!-margin-bottom-6" %>
                   <% end %>
                   <% if page.exit_pages.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2242,9 +2242,9 @@ en:
         <p>You need more than one question in your form before you can add any routes.</p>
         <p><a href="%{pages_link}">Back to your questions</a></p>
       too_many_options_html: |
-        <p>This question has a list with more than 10 options.</p>
-
-        <p>You cannot add routes from answers if the question has more than 10 options.</p>
+        <div class="govuk-inset-text">
+          <p>You cannot add routes from answers if the question has more than 10 options. We hope to add this ability soon.</p>
+        </div>
   routing_page:
     body_html: |
       <p> You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: </p>

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -6,15 +6,24 @@ RSpec.describe Forms::RouteInput, type: :model do
   let(:check_your_answers_value) { GotoValue::EndOfFormValue.new }
   let(:default_value) { GotoValue::DefaultValue.new }
 
-  let(:page) { build_stubbed(:page, position: 1) }
+  let(:page) do
+    build_stubbed(
+      :page,
+      :with_selection_settings,
+      position: 1,
+      selection_options: [{ name: "Yes", value: "Yes" }, { name: "No", value: "No" }],
+    )
+  end
+
   let(:goto_page) { build_stubbed(:page, position: 2) }
+  let(:answer_value) { "Yes" }
 
   let(:attributes) do
     {
       id: 1,
       page_id: page.id,
       goto: "page_#{goto_page.id}",
-      answer_value: "Yes",
+      answer_value:,
       page: page,
       goto_page: goto_page,
     }
@@ -123,15 +132,10 @@ RSpec.describe Forms::RouteInput, type: :model do
   end
 
   describe "#label_text" do
-    context "when the route is to the next page" do
-      it "returns the correct label" do
-        expect(route_input.label_text).to eq("After question 1, go to:")
-      end
-    end
-
     context "when the route is for a generic page" do
       let(:middle_page) { build_stubbed(:page, position: 2) }
       let(:goto_page) { build_stubbed(:page, position: 3) }
+      let(:answer_value) { nil }
 
       it "sets the label correctly for a generic page" do
         expect(route_input.label_text).to eq("After question 1, go to:")
@@ -141,7 +145,7 @@ RSpec.describe Forms::RouteInput, type: :model do
     context "when the route is for a selection page" do
       let(:page) { build_stubbed(:page, :with_selection_settings, position: 1) }
       let(:goto_page) { build_stubbed(:page, position: 2) }
-      let(:attributes) { super().merge(answer_value: "Option 1") }
+      let(:answer_value) { "Option 1" }
 
       it "sets the label correctly for a selection page" do
         expect(route_input.label_text).to eq("If option 1 (Option 1), go to:")
@@ -151,7 +155,7 @@ RSpec.describe Forms::RouteInput, type: :model do
     context "when the route is for a selection page with a none of the above option" do
       let(:page) { build_stubbed(:page, :with_selection_settings, position: 1) }
       let(:goto_page) { build_stubbed(:page, position: 2) }
-      let(:attributes) { super().merge(answer_value: Condition::NONE_OF_THE_ABOVE) }
+      let(:answer_value) { Condition::NONE_OF_THE_ABOVE }
 
       it "sets the label correctly for a selection page with a none of the above option" do
         expect(route_input.label_text).to eq("If option 3 (None of the above), go to:")
@@ -172,6 +176,7 @@ RSpec.describe Forms::RouteInput, type: :model do
     context "when the route is backwards" do
       let(:page) { build_stubbed(:page, position: 2) }
       let(:goto_page) { build_stubbed(:page, position: 1) }
+      let(:answer_value) { nil }
 
       it "adds the correct error" do
         expect(route_input).to be_invalid
@@ -180,7 +185,7 @@ RSpec.describe Forms::RouteInput, type: :model do
 
       context "when the route is for a selection question" do
         let(:page) { build_stubbed(:page, :with_selection_settings, position: 2) }
-        let(:attributes) { super().merge(answer_value: "Option 1") }
+        let(:answer_value) { "Option 1" }
 
         it "adds the correct error" do
           expect(route_input).to be_invalid

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Forms::RoutesInput do
     end
   end
 
-  describe "#route_with_selection_options" do
+  describe "#route_with_selection_options?" do
     context "when given a page with less than 10 selection options, only one option" do
       let(:page) { build(:page, :with_selection_settings) }
 
@@ -186,6 +186,40 @@ RSpec.describe Forms::RoutesInput do
 
       it "returns false" do
         expect(described_class.route_with_selection_options?(page)).to be false
+      end
+    end
+  end
+
+  describe "#can_have_exit_pages?" do
+    context "when given a page with less than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings) }
+
+      it "returns true" do
+        expect(described_class.can_have_exit_pages?(page)).to be true
+      end
+    end
+
+    context "when given a page with more than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings, selection_options: (1..11).to_a.map { |i| { name: i.to_s, value: i.to_s } }) }
+
+      it "returns false" do
+        expect(described_class.can_have_exit_pages?(page)).to be false
+      end
+    end
+
+    context "when given a selection page with checkboxes" do
+      let(:page) { build(:page, :selection_with_checkboxes) }
+
+      it "returns false" do
+        expect(described_class.can_have_exit_pages?(page)).to be false
+      end
+    end
+
+    context "when given a page which isn't a selection type" do
+      let(:page) { build(:page, :with_text_settings) }
+
+      it "returns false" do
+        expect(described_class.can_have_exit_pages?(page)).to be false
       end
     end
   end

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -171,6 +171,40 @@ RSpec.describe Forms::RoutesInput do
       it "returns :generic_route" do
         expect(described_class.routes_type(page)).to eq :generic_route
       end
+
+      context "with existing conditions" do
+        context "with selection options routes" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: "1",
+            )
+          end
+
+          it "returns :existing_selection_options_routes" do
+            expect(described_class.routes_type(page)).to eq :existing_selection_options_routes
+          end
+        end
+
+        context "with generic route" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: nil,
+            )
+          end
+
+          it "returns :generic_route" do
+            expect(described_class.routes_type(page)).to eq :generic_route
+          end
+        end
+      end
     end
 
     context "when given a selection page with checkboxes" do
@@ -205,6 +239,40 @@ RSpec.describe Forms::RoutesInput do
       it "returns false" do
         expect(described_class.route_with_selection_options?(page)).to be false
       end
+
+      context "with existing conditions" do
+        context "with selection options routes" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: "1",
+            )
+          end
+
+          it "returns true" do
+            expect(described_class.route_with_selection_options?(page)).to be true
+          end
+        end
+
+        context "with generic route" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: nil,
+            )
+          end
+
+          it "returns false" do
+            expect(described_class.route_with_selection_options?(page)).to be false
+          end
+        end
+      end
     end
 
     context "when given a selection page with checkboxes" do
@@ -238,6 +306,40 @@ RSpec.describe Forms::RoutesInput do
 
       it "returns false" do
         expect(described_class.can_have_exit_pages?(page)).to be false
+      end
+
+      context "with existing conditions" do
+        context "with selection options routes" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: "1",
+            )
+          end
+
+          it "returns true" do
+            expect(described_class.can_have_exit_pages?(page)).to be true
+          end
+        end
+
+        context "with generic route" do
+          before do
+            page.routing_conditions << build(
+              :condition,
+              routing_page: page,
+              check_page: page,
+              goto_page: build(:page, form: page.form),
+              answer_value: nil,
+            )
+          end
+
+          it "returns false" do
+            expect(described_class.can_have_exit_pages?(page)).to be false
+          end
+        end
       end
     end
 

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -156,6 +156,40 @@ RSpec.describe Forms::RoutesInput do
     end
   end
 
+  describe "#routes_type" do
+    context "when given a page with less than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings) }
+
+      it "returns :selection_options_routes" do
+        expect(described_class.routes_type(page)).to eq :selection_options_routes
+      end
+    end
+
+    context "when given a page with more than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings, selection_options: (1..11).to_a.map { |i| { name: i.to_s, value: i.to_s } }) }
+
+      it "returns :generic_route" do
+        expect(described_class.routes_type(page)).to eq :generic_route
+      end
+    end
+
+    context "when given a selection page with checkboxes" do
+      let(:page) { build(:page, :selection_with_checkboxes) }
+
+      it "returns :generic_route" do
+        expect(described_class.routes_type(page)).to eq :generic_route
+      end
+    end
+
+    context "when given a page which isn't a selection type" do
+      let(:page) { build(:page, :with_text_settings) }
+
+      it "returns :generic_route" do
+        expect(described_class.routes_type(page)).to eq :generic_route
+      end
+    end
+  end
+
   describe "#route_with_selection_options?" do
     context "when given a page with less than 10 selection options, only one option" do
       let(:page) { build(:page, :with_selection_settings) }

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -120,6 +120,39 @@ RSpec.describe Routes::BuildService do
             expect(routes).to all be_a(Forms::RouteInput)
             expect(routes.filter { it.page_id == pages.first.id }.length).to eq(1)
           end
+
+          context "and has a generic route" do
+            before do
+              pages.first.routing_conditions << create(:condition, routing_page_id: pages.first.id, goto_page_id: pages.third.id, answer_value: nil)
+            end
+
+            it "builds a single route input for the selection page" do
+              routes = service.build_routes
+
+              expect(routes.length).to eq(3)
+              expect(routes).to all be_a(Forms::RouteInput)
+              expect(routes.filter { it.page_id == pages.first.id }.length).to eq(1)
+            end
+          end
+
+          context "and has existing routing conditions" do
+            before do
+              pages.first.routing_conditions << [
+                create(:condition, routing_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id),
+                create(:condition, routing_page_id: pages.first.id, answer_value: "Option 11", skip_to_end: true),
+              ]
+            end
+
+            it "builds a route input for each option with a condition" do
+              pages.each(&:reload)
+
+              routes = service.build_routes
+
+              expect(routes.length).to eq(4)
+              expect(routes).to all be_a(Forms::RouteInput)
+              expect(routes.filter { it.page_id == pages.first.id }.length).to eq(2)
+            end
+          end
         end
 
         context "when the selection page is optional" do

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -380,9 +380,8 @@ describe "routes/show.html.erb" do
           render_page
 
           expected_content = <<~TEXT
-            This question has a list with more than 10 options.
-
-            You cannot add routes from answers if the question has more than 10 options.
+            You cannot add routes from answers if the question has more than 10 options. \
+            We hope to add this ability soon.
           TEXT
 
           expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -257,7 +257,7 @@ describe "routes/show.html.erb" do
     context "when a page is a select from a list question" do
       let(:pages) do
         [
-          build_stubbed(:page, :with_selection_settings, id: 101, selection_options:),
+          build_stubbed(:page, :with_selection_settings, id: 101, selection_options:, routing_conditions:),
           build_stubbed(:page, id: 102),
           build_stubbed(:page, id: 103),
         ]
@@ -265,6 +265,10 @@ describe "routes/show.html.erb" do
 
       let(:selection_options) do
         [{ name: "Yes", value: "Yes" }, { name: "No", value: "No" }]
+      end
+
+      let(:routing_conditions) do
+        []
       end
 
       it "has inputs for each answer option" do
@@ -310,6 +314,65 @@ describe "routes/show.html.erb" do
             expect(rows[0]).to have_selector(".govuk-select", count: 1)
             expect(rows[1]).to have_selector(".govuk-select", count: 1)
             expect(rows[2]).not_to have_selector(".govuk-select")
+          end
+        end
+
+        it "does not have a button for adding exit pages" do
+          render_page
+          expect(rendered).not_to have_button("Add an exit page")
+          expect(rendered).not_to have_selector("button[name='new_exit_page'][value='#{pages.first.id}']")
+        end
+
+        context "with a generic routing condition" do
+          let(:routing_conditions) do
+            [
+              build_stubbed(:condition, routing_page_id: 101, goto_page_id: 103, answer_value: nil),
+            ]
+          end
+
+          it "has one route input for that question" do
+            render_page
+
+            expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+              rows = summary_list.find_all(".govuk-summary-list__row")
+
+              expect(rows[0]).to have_selector(".govuk-select", count: 1)
+              expect(rows[1]).to have_selector(".govuk-select", count: 1)
+              expect(rows[2]).not_to have_selector(".govuk-select")
+            end
+          end
+
+          it "does not have a button for adding exit pages" do
+            render_page
+            expect(rendered).not_to have_button("Add an exit page")
+            expect(rendered).not_to have_selector("button[name='new_exit_page'][value='#{pages.first.id}']")
+          end
+        end
+
+        context "with existing routing conditions" do
+          let(:routing_conditions) do
+            [
+              build_stubbed(:condition, routing_page_id: 101, goto_page_id: 103, answer_value: "Option 5"),
+              build_stubbed(:condition, routing_page_id: 101, skip_to_end: true, answer_value: "Option 10"),
+            ]
+          end
+
+          it "has inputs for each selection option with a condition" do
+            render_page
+
+            expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+              rows = summary_list.find_all(".govuk-summary-list__row")
+
+              expect(rows[0]).to have_selector(".govuk-select", count: 2)
+              expect(rows[1]).to have_selector(".govuk-select", count: 1)
+              expect(rows[2]).not_to have_selector(".govuk-select")
+            end
+          end
+
+          it "has a button for adding exit pages" do
+            render_page
+            expect(rendered).to have_button("Add an exit page")
+            expect(rendered).to have_selector("button[name='new_exit_page'][value='#{pages.first.id}']")
           end
         end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/R6lOpwZC/3214-show-route-inputs-on-edit-question-routes-page-for-selection-questions-with-more-than-10-options <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently, when the multiple branches feature flag is enabled, for selection questions with more than 10 options we don't allow form creators to add routes for those selection options, we just treat it as a generic question. This is because the edit question routes page could get impractically long otherwise.

However, when the multiple feature is not enabled (the default in production), we do allow form creators to add routes to a long selection question, so there are already some forms in production with routes for a selection question with more than 10 options.

To make sure form creators are still able to edit these forms (and that these forms won't be broken by the edit question routes page), we've decided to show the route inputs for existing routes only for a long selection question. This means affected form creators won't be able to add new routes once the feature flag is enabled for their forms, but they will be able to see and edit existing ones.

We hope to iterate on the multiple branches feature in future to allow form creators to add routes to long selection questions without the edit question routes page becoming more difficult to use.

This PR adds a new method `Forms::RoutesInput.routes_type`, that tells the `Routes::BuildService` how to create route inputs for a form. `Routes::BuildService#build_routes` will now create selection option route inputs for a long selection question, but only for existing conditions. The `.routes_for_selection_options?` method is updated to treat either selection questions with 10 options or less or selection questions with more than 10 options and existing conditions (for a selection option) as a route for selection options, so other places where we care about whether the route is for a selection option or not is still correct.

The logic for `.routes_type` is quite complex, because we need to make sure that if a form creator has a long selection question without routes, and then sets the generic catch-all route for it, it doesn't then get treated as a long selection question with selection options routes. I tried different ways of writing out the conditionals, I settled on this being the most readable, but am definitely open to other suggestions!

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
