### PR TITLE
Remove feature flag for showing relevant organisations

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -31,7 +31,6 @@ locals {
     { name = "SETTINGS__AWS__ASSETS_S3_BUCKET_NAME", value = local.assets_bucket_name },
     { name = "SETTINGS__FORMS_ENV", value = "review" },
     { name = "SETTINGS__FORMS_RUNNER__URL", value = "https://forms.service.gov.uk" },
-    { name = "SETTINGS__FEATURES__SHOW_RELEVANT_ORGANISATIONS", value = "true" }
   ]
 }
 

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -73,11 +73,7 @@ module Account
     end
 
     def allowed_organisations
-      @allowed_organisations ||= if FeatureService.enabled?(:show_relevant_organisations)
-                                   Organisation.not_closed.for_domain(current_user.email_domain).order(:name)
-                                 else
-                                   Organisation.not_closed.order(:name)
-                                 end
+      @allowed_organisations ||= Organisation.not_closed.for_domain(current_user.email_domain).order(:name)
     end
   end
 end

--- a/app/input_objects/account/organisation_input.rb
+++ b/app/input_objects/account/organisation_input.rb
@@ -22,7 +22,7 @@ class Account::OrganisationInput < BaseInput
   end
 
   def radios?
-    FeatureService.enabled?(:show_relevant_organisations) && allowed_organisations.size <= 30
+    allowed_organisations.size <= 30
   end
 
   def not_listed_selected?

--- a/app/views/account/organisations/edit.html.erb
+++ b/app/views/account/organisations/edit.html.erb
@@ -6,14 +6,11 @@
         <%= f.govuk_error_summary %>
       <% end %>
 
-      <% show_relevant_organisations_enabled = FeatureService.enabled?(:show_relevant_organisations) %>
-      <% if show_relevant_organisations_enabled %>
-        <h1 class="govuk-heading-l">
-          <%= t("page_titles.account_organisation") %>
-        </h1>
+      <h1 class="govuk-heading-l">
+        <%= t("page_titles.account_organisation") %>
+      </h1>
 
-        <p><%= t(".you_created_account_with", email_domain: @organisation_input.user.email_domain) %></p>
-      <% end %>
+      <p><%= t(".you_created_account_with", email_domain: @organisation_input.user.email_domain) %></p>
 
       <% if @organisation_input.radios? %>
         <%= f.govuk_radio_buttons_fieldset(:organisation_id, legend: { size: 'm', tag: 'h2' }) do %>
@@ -34,12 +31,6 @@
               ) %>
         <% end %>
       <% else %>
-        <% label_options = if show_relevant_organisations_enabled
-                             { size: 'm', tag: 'h2', text: t("helpers.legend.account_organisation_input.organisation_id") }
-                           else
-                             { size: 'xl', tag: 'h1' }
-                           end %>
-
         <%= render DfE::Autocomplete::View.new(
           f,
           attribute_name: :organisation_id,
@@ -50,7 +41,7 @@
             :name_with_abbreviation,
             class: ['govuk-!-width-three-quarters'],
             options: { prompt: t('users.edit.organisation_prompt') },
-            label: label_options,
+            label: { size: 'm', tag: 'h2', text: t("helpers.legend.account_organisation_input.organisation_id") },
           ),
           html_attributes: { 'data-show-all-values' => 'true' },
         ) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,7 +8,6 @@ features:
     enabled_by_group: true
   save_and_return:
     enabled_by_group: true
-  show_relevant_organisations: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,8 +22,6 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :show_relevant_organisations, features, false
-
     describe "group-scoped feature flags" do
       group_features = features.select { |_, config| config.is_a?(Hash) && config["enabled_by_group"] }
 

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -11,53 +11,36 @@ describe Account::OrganisationsController do
   describe "GET #edit" do
     context "when there is more than one organisation the user can select" do
       context "when the user does not have an organisation" do
-        context "when the show_relevant_organisations feature is enabled", :feature_show_relevant_organisations do
-          it "assign the input object with allowed organisations limited by the user's domain" do
-            matching_orgs = [
-              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
-              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
-            ]
-            create(:organisation, organisation_domains: [create(:organisation_domain, domain: "example.com")])
-            create(:organisation, closed: true, organisation_domains: [create(:organisation_domain, domain: domain)])
+        it "assign the input object with allowed organisations limited by the user's domain" do
+          matching_orgs = [
+            create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
+            create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
+          ]
+          create(:organisation, organisation_domains: [create(:organisation_domain, domain: "example.com")])
+          create(:organisation, closed: true, organisation_domains: [create(:organisation_domain, domain: domain)])
 
+          get edit_account_organisation_path
+
+          expect(response).to render_template(:edit)
+
+          input_object = assigns(:organisation_input)
+          expect(input_object).to be_a(Account::OrganisationInput)
+          expect(input_object.allowed_organisations).to match_array(matching_orgs)
+        end
+
+        context "when there are no organisations the user can select" do
+          it "renders the no_matches template" do
             get edit_account_organisation_path
-
-            expect(response).to render_template(:edit)
-
-            input_object = assigns(:organisation_input)
-            expect(input_object).to be_a(Account::OrganisationInput)
-            expect(input_object.allowed_organisations).to match_array(matching_orgs)
-          end
-
-          context "when there are no organisations the user can select" do
-            it "renders the no_matches template" do
-              get edit_account_organisation_path
-              expect(response).to render_template(:no_matches)
-            end
-          end
-
-          context "when there is only one organisation the user can select" do
-            it "redirects to the confirm organisation path" do
-              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
-
-              get edit_account_organisation_path
-              expect(response).to redirect_to(show_confirm_account_organisation_path)
-            end
+            expect(response).to render_template(:no_matches)
           end
         end
 
-        context "when the show_relevant_organisations feature is disabled", feature_show_relevant_organisations: false do
-          it "assigns the input object with all not closed organisations" do
-            orgs = create_list(:organisation, 2)
-            create(:organisation, closed: true)
+        context "when there is only one organisation the user can select" do
+          it "redirects to the confirm organisation path" do
+            create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
 
             get edit_account_organisation_path
-
-            expect(response).to render_template(:edit)
-
-            input_object = assigns(:organisation_input)
-            expect(input_object).to be_a(Account::OrganisationInput)
-            expect(input_object.allowed_organisations).to match_array(orgs)
+            expect(response).to redirect_to(show_confirm_account_organisation_path)
           end
         end
       end
@@ -134,42 +117,24 @@ describe Account::OrganisationsController do
       end
     end
 
-    context "when the show_relevant_organisations feature is enabled", :feature_show_relevant_organisations do
-      context "when the selected organisation does not match the user's email domain" do
-        let(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: "other.gov.uk")]) }
-        let(:invalid_params) { { account_organisation_input: { organisation_id: organisation.id } } }
+    context "when the selected organisation does not match the user's email domain" do
+      let(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: "other.gov.uk")]) }
+      let(:invalid_params) { { account_organisation_input: { organisation_id: organisation.id } } }
 
-        before do
-          create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
-        end
-
-        it "does not update the user's organisation" do
-          expect {
-            put account_organisation_path, params: invalid_params
-          }.not_to(change { user.reload.organisation })
-        end
-
-        it "re-renders the edit template" do
-          put account_organisation_path, params: invalid_params
-          expect(response).to have_http_status(:unprocessable_content)
-          expect(response).to render_template(:edit)
-        end
+      before do
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
       end
-    end
 
-    context "when the show_relevant_organisations feature is disabled", feature_show_relevant_organisations: false do
-      context "when the selected organisation does not match the user's email domain" do
-        let(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: "other.gov.uk")]) }
-        let(:params) { { account_organisation_input: { organisation_id: organisation.id } } }
+      it "does not update the user's organisation" do
+        expect {
+          put account_organisation_path, params: invalid_params
+        }.not_to(change { user.reload.organisation })
+      end
 
-        before do
-          create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
-        end
-
-        it "updates the user's organisation" do
-          put account_organisation_path, params: params
-          expect(user.reload.organisation).to eq(organisation)
-        end
+      it "re-renders the edit template" do
+        put account_organisation_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to render_template(:edit)
       end
     end
 
@@ -181,7 +146,7 @@ describe Account::OrganisationsController do
     end
   end
 
-  describe "GET #show_confirm", :feature_show_relevant_organisations do
+  describe "GET #show_confirm" do
     context "when there is only one organisation the user can select" do
       let!(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]) }
 
@@ -215,7 +180,7 @@ describe Account::OrganisationsController do
     end
   end
 
-  describe "POST #confirm", :feature_show_relevant_organisations do
+  describe "POST #confirm" do
     let(:params) { { account_confirm_organisation_input: { confirm: "yes" } } }
 
     context "when there is only one organisation the user can select" do

--- a/spec/views/account/organisations/edit.html.erb_spec.rb
+++ b/spec/views/account/organisations/edit.html.erb_spec.rb
@@ -31,9 +31,45 @@ describe "account/organisations/edit.html.erb" do
       expect(rendered).to have_button(I18n.t("save_and_continue"))
     end
 
-    context "when the show_relevant_organisations feature is disabled", feature_show_relevant_organisations: false do
-      it "has the expected h1" do
-        expect(rendered).to have_selector("h1", text: "Select your organisation")
+    it "has the expected h1" do
+      expect(rendered).to have_selector("h1", text: t("page_titles.account_organisation"))
+    end
+
+    it "displays the user's email domain" do
+      expect(rendered).to have_content(I18n.t("account.organisations.edit.you_created_account_with", email_domain: "example.com"))
+    end
+
+    context "when there are fewer than 30 organisations" do
+      it "has the expected h2" do
+        expect(rendered).to have_selector("h2", text: "Which of these organisations do you work for?")
+      end
+
+      it "renders the organisation radio buttons" do
+        expect(rendered).to have_selector('input[type="radio"][name="account_organisation_input[organisation_id]"]', count: organisations.size + 1)
+        organisations.each do |organisation|
+          expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-#{organisation.id}-field']", text: organisation.name_with_abbreviation)
+        end
+      end
+
+      it "has a divider" do
+        expect(rendered).to have_selector(".govuk-radios__divider", text: "or")
+      end
+
+      it "has a radio button for organisation not listed" do
+        expect(rendered).to have_selector("input[type='radio'][value='not_listed'][name='account_organisation_input[organisation_id]']")
+        expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-not-listed-field']", text: I18n.t("account.organisations.edit.not_listed_option"))
+      end
+
+      it "does not render the not listed details component" do
+        expect(rendered).not_to have_selector("details.govuk-details")
+      end
+    end
+
+    context "when there are more than 30 organisations" do
+      let(:organisations) { build_stubbed_list(:organisation, 31) }
+
+      it "has the expected h2" do
+        expect(rendered).to have_selector("h2", text: "Which of these organisations do you work for?")
       end
 
       it "renders the organisation select field for autocomplete" do
@@ -45,75 +81,14 @@ describe "account/organisations/edit.html.erb" do
 
       it "has organisation fields with abbreviations" do
         expect(rendered).to have_select(
-          "Select your organisation",
-          with_options: [
-            "Department for Testing (DfT)",
-            "Test Org (TO)",
-          ],
+          "Which of these organisations do you work for?",
+          with_options: organisations.map(&:name_with_abbreviation),
         )
       end
-    end
 
-    context "when the show_relevant_organisations feature is enabled", :feature_show_relevant_organisations do
-      it "has the expected h1" do
-        expect(rendered).to have_selector("h1", text: t("page_titles.account_organisation"))
-      end
-
-      it "displays the user's email domain" do
-        expect(rendered).to have_content(I18n.t("account.organisations.edit.you_created_account_with", email_domain: "example.com"))
-      end
-
-      context "when there are fewer than 30 organisations" do
-        it "has the expected h2" do
-          expect(rendered).to have_selector("h2", text: "Which of these organisations do you work for?")
-        end
-
-        it "renders the organisation radio buttons" do
-          expect(rendered).to have_selector('input[type="radio"][name="account_organisation_input[organisation_id]"]', count: organisations.size + 1)
-          organisations.each do |organisation|
-            expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-#{organisation.id}-field']", text: organisation.name_with_abbreviation)
-          end
-        end
-
-        it "has a divider" do
-          expect(rendered).to have_selector(".govuk-radios__divider", text: "or")
-        end
-
-        it "has a radio button for organisation not listed" do
-          expect(rendered).to have_selector("input[type='radio'][value='not_listed'][name='account_organisation_input[organisation_id]']")
-          expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-not-listed-field']", text: I18n.t("account.organisations.edit.not_listed_option"))
-        end
-
-        it "does not render the not listed details component" do
-          expect(rendered).not_to have_selector("details.govuk-details")
-        end
-      end
-
-      context "when there are more than 30 organisations" do
-        let(:organisations) { build_stubbed_list(:organisation, 31) }
-
-        it "has the expected h2" do
-          expect(rendered).to have_selector("h2", text: "Which of these organisations do you work for?")
-        end
-
-        it "renders the organisation select field for autocomplete" do
-          expect(rendered).to have_selector('select[name="account_organisation_input[organisation_id]"]', visible: :all)
-          organisations.each do |organisation|
-            expect(rendered).to have_selector("option[value='#{organisation.id}']", text: organisation.name)
-          end
-        end
-
-        it "has organisation fields with abbreviations" do
-          expect(rendered).to have_select(
-            "Which of these organisations do you work for?",
-            with_options: organisations.map(&:name_with_abbreviation),
-          )
-        end
-
-        it "renders the not listed details component" do
-          expect(rendered).to have_selector("details.govuk-details")
-          expect(rendered).to have_selector("summary.govuk-details__summary", text: I18n.t("account.organisations.edit.details_summary"))
-        end
+      it "renders the not listed details component" do
+        expect(rendered).to have_selector("details.govuk-details")
+        expect(rendered).to have_selector("summary.govuk-details__summary", text: I18n.t("account.organisations.edit.details_summary"))
       end
     end
   end


### PR DESCRIPTION
We released this feature a couple of weeks ago.

Trello card: https://trello.com/c/9D9j2WGu/3250-remove-feature-flag-for-showing-only-relevant-organisations 

See https://github.com/govuk-forms/forms-deploy/pull/2264 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
