### PR TITLE
Update Welsh CSV service for multiple exit pages

### DIFF
--- a/app/services/welsh_csv_service.rb
+++ b/app/services/welsh_csv_service.rb
@@ -43,7 +43,12 @@ private
       add_question_content(csv, page)
       add_selection_options(csv, page) if page.answer_type == "selection"
       add_none_of_above_question(csv, page) if has_none_of_the_above?(page)
-      add_routing_conditions(csv, page)
+
+      if FeatureService.new(group: form.group).enabled?(:multiple_branches)
+        add_exit_pages(csv, page)
+      else
+        add_routing_conditions(csv, page)
+      end
     end
   end
 
@@ -83,6 +88,15 @@ private
         csv << ["#{question_name(page)} - exit page heading", condition.exit_page_heading, condition.exit_page_heading_cy]
         csv << ["#{question_name(page)} - exit page content", condition.exit_page_markdown, condition.exit_page_markdown_cy]
       end
+    end
+  end
+
+  def add_exit_pages(csv, page)
+    exit_page_positions = ExitPage.positions_for_page(page)
+    page.exit_pages.each do |exit_page|
+      exit_page_position = exit_page_positions[exit_page.id]
+      csv << ["#{question_name(page)} - exit page #{exit_page_position} heading", exit_page.heading, exit_page.heading_cy]
+      csv << ["#{question_name(page)} - exit page #{exit_page_position} content", exit_page.markdown, exit_page.markdown_cy]
     end
   end
 

--- a/spec/services/welsh_csv_service_spec.rb
+++ b/spec/services/welsh_csv_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "WelshCsvService" do
+RSpec.describe "WelshCsvService", feature_multiple_branches: false do
   describe "#as_csv" do
     let(:form) { build :form }
 
@@ -208,17 +208,103 @@ RSpec.describe "WelshCsvService" do
       end
     end
 
-    context "when the page has an exit condition" do
-      let(:form) { build :form, :with_pages, pages: [page] }
-      let(:page) { create :page, position: 1, routing_conditions: [condition] }
-      let(:condition) { create :condition, :with_exit_page, exit_page_heading: "Exit page heading", exit_page_markdown: "Exit page markdown", exit_page_heading_cy: "Welsh exit page heading", exit_page_markdown_cy: "Welsh exit page markdown" }
+    context "when the page has an exit page" do
+      context "when the multiple branches feature is enabled", :feature_multiple_branches do
+        let(:form) do
+          create(
+            :form,
+            :with_pages,
+            pages: [
+              build(
+                :page,
+                position: 1,
+                exit_pages: [
+                  build(
+                    :exit_page,
+                    heading: "Exit page 1 for question 1 heading",
+                    markdown: "Exit page 1 for question 1 markdown.",
+                    heading_cy: "Welsh exit page 1 for question 1 heading",
+                    markdown_cy: "Welsh exit page 1 for question 1 markdown.",
+                  ),
+                ],
+              ),
+              build(
+                :page,
+                position: 2,
+                exit_pages: [
+                  build(
+                    :exit_page,
+                    heading: "Exit page 1 for question 2 heading",
+                    markdown: "Exit page 1 for question 2 markdown.",
+                    heading_cy: "Welsh exit page 1 for question 2 heading",
+                    markdown_cy: "Welsh exit page 1 for question 2 markdown.",
+                  ),
+                  build(
+                    :exit_page,
+                    heading: "Exit page 2 for question 2 heading",
+                    markdown: "Exit page 2 for question 2 markdown.",
+                    heading_cy: "Welsh exit page 2 for question 2 heading",
+                    markdown_cy: "Welsh exit page 2 for question 2 markdown.",
+                  ),
+                ],
+              ),
+            ],
+          )
+        end
 
-      it "contains the exit page heading" do
-        expect(csv_rows(form)).to include([
-          "Question 1 - exit page heading",
-          "Exit page heading",
-          "Welsh exit page heading",
-        ])
+        it "contains the exit page headings" do
+          expect(csv_rows(form)).to include(
+            [
+              "Question 1 - exit page 1 heading",
+              "Exit page 1 for question 1 heading",
+              "Welsh exit page 1 for question 1 heading",
+            ],
+            [
+              "Question 2 - exit page 1 heading",
+              "Exit page 1 for question 2 heading",
+              "Welsh exit page 1 for question 2 heading",
+            ],
+            [
+              "Question 2 - exit page 2 heading",
+              "Exit page 2 for question 2 heading",
+              "Welsh exit page 2 for question 2 heading",
+            ],
+          )
+        end
+
+        it "contains the exit page markdown" do
+          expect(csv_rows(form)).to include(
+            [
+              "Question 1 - exit page 1 content",
+              "Exit page 1 for question 1 markdown.",
+              "Welsh exit page 1 for question 1 markdown.",
+            ],
+            [
+              "Question 2 - exit page 1 content",
+              "Exit page 1 for question 2 markdown.",
+              "Welsh exit page 1 for question 2 markdown.",
+            ],
+            [
+              "Question 2 - exit page 2 content",
+              "Exit page 2 for question 2 markdown.",
+              "Welsh exit page 2 for question 2 markdown.",
+            ],
+          )
+        end
+      end
+
+      context "when the multiple branches feature is not enabled", feature_multiple_branches: false do
+        let(:form) { build :form, :with_pages, pages: [page] }
+        let(:page) { create :page, position: 1, routing_conditions: [condition] }
+        let(:condition) { create :condition, :with_exit_page, exit_page_heading: "Exit page heading", exit_page_markdown: "Exit page markdown", exit_page_heading_cy: "Welsh exit page heading", exit_page_markdown_cy: "Welsh exit page markdown" }
+
+        it "contains the exit page heading" do
+          expect(csv_rows(form)).to include([
+            "Question 1 - exit page heading",
+            "Exit page heading",
+            "Welsh exit page heading",
+          ])
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Qe1U2bBO/3181-change-welsh-translation-feature-to-work-with-multiple-exit-pages <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When the multiple branches feature is released, the Welsh translation CSV should include the number for each exit page in the row heading, so that exit pages can be uniquely identified for a form when there's a page with more than one exit page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
