### PR TITLE
Update selection question type warning message for multiple branches

### DIFF
--- a/app/views/pages/selection/type.html.erb
+++ b/app/views/pages/selection/type.html.erb
@@ -7,12 +7,13 @@
     <% if @page.present? && @page.routing_conditions.any? %>
       <% if @selection_type_input.need_to_reduce_options? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-          <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>
+          <% routes = t("selection_type.routes", count: @page.routing_conditions.count) %>
+          <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes:), tag: "h3") %>
           <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
         <% end %>
       <% elsif @selection_type_input.show_routing_warning? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-          <% banner.with_heading(text: t("selection_type.routing_warning")) %>
+          <% banner.with_heading(text: t("selection_type.routing_warning", count: @page.routing_conditions.count)) %>
         <% end %>
       <% end %>
     <% elsif @selection_type_input.need_to_reduce_options? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2310,11 +2310,16 @@ en:
   selection_type:
     reduce_your_options_warning:
       body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
-      heading: If you change this to ‘one or more options’, you’ll need to edit your list
+      heading: If you change this to ‘One or more options’, you’ll need to edit your list
+    routes:
+      one: route
+      other: routes
     routing_and_reduce_your_options_combined_warning:
       body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
-      heading: If you change this to ‘one or more options’, the route from this question will be deleted and you’ll need to edit the list
-    routing_warning: If you change this to ‘one or more options’, the route from this question will be deleted
+      heading: If you change this to ‘One or more options’, this question’s %{routes} will be deleted and you’ll need to edit the list
+    routing_warning:
+      one: If you change this to ‘One or more options’, this question’s route will be deleted
+      other: If you change this to ‘One or more options’, this question’s routes will be deleted
   set_email:
     new:
       body_html: |

--- a/spec/views/pages/selection/type.html.erb_spec.rb
+++ b/spec/views/pages/selection/type.html.erb_spec.rb
@@ -91,7 +91,15 @@ describe "pages/selection/type.html.erb", type: :view do
 
             context "when show_routing_warning returns true" do
               it "displays a warning about routes being deleted" do
-                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning"))
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning", count: 1))
+              end
+
+              context "with more than one route from options" do
+                let(:routing_conditions) { build_list(:condition, 3) }
+
+                it "displays a warning about routes being deleted" do
+                  expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning", count: 3))
+                end
               end
             end
 
@@ -111,7 +119,15 @@ describe "pages/selection/type.html.erb", type: :view do
             end
 
             it "displays a combined warning about routes being deleted and needing to reduce the options" do
-              expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading"))
+              expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes: "route"))
+            end
+
+            context "with more than one route from options" do
+              let(:routing_conditions) { build_list(:condition, 3) }
+
+              it "displays a combined warning about routes being deleted and needing to reduce the options" do
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes: "routes"))
+              end
             end
           end
         end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/PzJ1n9dI/3243-update-wording-of-the-banner-when-changing-whether-selection-question-can-have-more-than-one-answer <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Selection questions can have one or more routing conditions when multiple branches is enabled, update the warning messages on the page for changing the type of a selection question to reflect this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
