### PR TITLE
Update warning messages for exit pages for multiple branches

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -20,10 +20,10 @@ class PagesController < FormsController
 
     if FeatureService.new(group: current_form.group).enabled?(:multiple_branches)
       @page_conditions = page.routing_conditions
-      @routing = @page_conditions + @page_goto_conditions
+      @routing = @page_conditions + @page_goto_conditions + page.exit_pages
       if @routing.present?
-        @routing_banner_heading = routing_banner_heading(@page_conditions, @page_goto_conditions)
-        @routing_banner_html = routing_banner_html(@page_conditions, @page_goto_conditions)
+        @routing_banner_heading = routing_banner_heading(@page_conditions, @page_goto_conditions, page.exit_pages)
+        @routing_banner_html = routing_banner_html(@page_conditions, @page_goto_conditions, page.exit_pages)
       end
     elsif page.routing_conditions.any? && page.routing_conditions.first.secondary_skip?
       @routing = :start_of_secondary_skip_route
@@ -189,23 +189,30 @@ private
     CurrentLoggingAttributes.validation_errors = errors.map { |error| "PageList: #{error}" } if errors.any?
   end
 
-  def routing_banner_heading(page_conditions, goto_conditions)
+  def routing_banner_heading(page_conditions, goto_conditions, exit_pages)
     if page_conditions.present? && goto_conditions.present?
       t("pages.delete.routing_and_goto_heading", question_number: page.position)
     elsif page_conditions.present?
       t("pages.delete.routing_heading", question_number: page.position, count: page_conditions.count)
     elsif goto_conditions.present?
       t("pages.delete.goto_heading", question_number: page.position, count: goto_conditions.count)
+    elsif exit_pages.present?
+      t("pages.delete.exit_pages_heading", question_number: page.position, count: exit_pages.count)
     end
   end
 
-  def routing_banner_html(page_conditions, goto_conditions)
+  def routing_banner_html(page_conditions, goto_conditions, exit_pages)
     if page_conditions.present? && goto_conditions.present?
-      t("pages.delete.routing_and_goto_html", routes_href: routes_path(current_form.id))
+      routes_and_exit_pages = helpers.routes_and_exit_pages(page, count_goto_conditions: true)
+      t("pages.delete.routing_and_goto_html", routes_and_exit_pages:, routes_href: routes_path(current_form.id))
     elsif page_conditions.present?
-      t("pages.delete.routing_html", question_number: page.position, count: page_conditions.count, routes_href: routes_path(current_form.id))
+      routes_and_exit_pages = helpers.routes_and_exit_pages(page)
+      t("pages.delete.routing_html", question_number: page.position, routes_and_exit_pages:, routes_href: routes_path(current_form.id))
     elsif goto_conditions.present?
       t("pages.delete.goto_html", question_number: page.position, count: goto_conditions.count, routes_href: routes_path(current_form.id))
+    elsif exit_pages.present?
+      exit_pages = t("helpers.pages.exit_pages", count: exit_pages.count)
+      t("pages.delete.exit_pages_html", question_number: page.position, exit_pages:, routes_href: routes_path(current_form.id))
     end
   end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -56,4 +56,24 @@ module PagesHelper
 
     { heading: "There are routes from some of these options", text: "If you remove or change an option with a route, the route will be deleted. #{edit_routes_link}" }
   end
+
+  def routes_and_exit_pages(page, count_goto_conditions: false)
+    exit_pages = page.exit_pages
+    routes = page.routing_conditions
+    routes += page.goto_conditions if count_goto_conditions
+
+    if routes.any? && exit_pages.any?
+      I18n.t(
+        "helpers.pages.routes_and_exit_pages",
+        routes: I18n.t("helpers.pages.routes", count: routes.size),
+        exit_pages: I18n.t("helpers.pages.exit_pages", count: exit_pages.size),
+      )
+    elsif routes.any?
+      I18n.t("helpers.pages.routes", count: routes.size)
+    elsif exit_pages.any?
+      I18n.t("helpers.pages.exit_pages", count: exit_pages.size)
+    else
+      ""
+    end
+  end
 end

--- a/app/views/pages/selection/type.html.erb
+++ b/app/views/pages/selection/type.html.erb
@@ -7,18 +7,29 @@
     <% if @page.present? && @page.routing_conditions.any? %>
       <% if @selection_type_input.need_to_reduce_options? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-          <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>
+          <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes_and_exit_pages: routes_and_exit_pages(@page)), tag: "h3") %>
           <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
         <% end %>
       <% elsif @selection_type_input.show_routing_warning? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-          <% banner.with_heading(text: t("selection_type.routing_warning")) %>
+          <% banner.with_heading(text: t("selection_type.routing_warning", routes_and_exit_pages: routes_and_exit_pages(@page))) %>
         <% end %>
+      <% end %>
+    <% elsif @selection_type_input.need_to_reduce_options? && @page.exit_pages.any? %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+        <% exit_pages = t("helpers.pages.exit_pages", count: @page.exit_pages.size) %>
+        <% banner.with_heading(text: t("selection_type.exit_pages_and_reduce_your_options_combined_warning.heading", exit_pages:), tag: "h3") %>
+        <p><%= t("selection_type.exit_pages_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
       <% end %>
     <% elsif @selection_type_input.need_to_reduce_options? %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("selection_type.reduce_your_options_warning.heading"), tag: "h3") %>
         <p><%= t("selection_type.reduce_your_options_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
+      <% end %>
+    <% elsif @page.present? && @page.exit_pages.any? %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+        <% exit_pages = t("helpers.pages.exit_pages", count: @page.exit_pages.size) %>
+        <% banner.with_heading(text: t("selection_type.exit_pages_warning", exit_pages:)) %>
       <% end %>
     <% end %>
 

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,9 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.routing_conditions.any? { it.answer_value.present? } %>
+    <% if @page.present? && (@page.routing_conditions.any? { it.answer_value.present? } || @page.exit_pages.any?) %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-        <% banner.with_heading(text: t("type_of_answer.routing_warning_changing_from_one_option_heading", count: @page.routing_conditions.count), tag: "h3") %>
+        <% banner.with_heading(text: t("type_of_answer.routing_warning_changing_from_one_option_heading", routes_and_exit_pages: routes_and_exit_pages(@page)), tag: "h3") %>
       <% end %>
     <% end %>
 

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.routing_conditions.any? && @page.answer_settings.only_one_option == "true" %>
+    <% if @page.present? && @page.routing_conditions.any? { it.answer_value.present? } %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_changing_from_one_option_heading", count: @page.routing_conditions.count), tag: "h3") %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1315,6 +1315,14 @@ en:
         is_optional: Should this additional question be mandatory or optional?
       pages_selection_options_input:
         include_none_of_the_above: Should the list include an option for ‘None of the above’?
+    pages:
+      exit_pages:
+        one: exit page
+        other: exit pages
+      routes:
+        one: route
+        other: routes
+      routes_and_exit_pages: "%{routes} and %{exit_pages}"
   home:
     actions: Actions
     change_filter: Change

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2323,13 +2323,17 @@ en:
     up_to_3000_options: You can have up to 3,000 options.
     up_to_30_options: You can have up to 30 options.
   selection_type:
+    exit_pages_and_reduce_your_options_combined_warning:
+      body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
+      heading: If you change this to ‘One or more options’, this question’s %{exit_pages} will be deleted and you’ll need to edit the list
+    exit_pages_warning: If you change this to ‘One or more options’, this question’s %{exit_pages} will be deleted
     reduce_your_options_warning:
       body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
-      heading: If you change this to ‘one or more options’, you’ll need to edit your list
+      heading: If you change this to ‘One or more options’, you’ll need to edit your list
     routing_and_reduce_your_options_combined_warning:
       body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
-      heading: If you change this to ‘one or more options’, the route from this question will be deleted and you’ll need to edit the list
-    routing_warning: If you change this to ‘one or more options’, the route from this question will be deleted
+      heading: If you change this to ‘One or more options’, this question’s %{routes_and_exit_pages} will be deleted and you’ll need to edit the list
+    routing_warning: If you change this to ‘One or more options’, this question’s %{routes_and_exit_pages} will be deleted
   set_email:
     new:
       body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1886,6 +1886,13 @@ en:
         back_link: Back to question %{question_number}’s routes
       hint_html: "<p>You can skip people who select one specific answer to question %{question_number} to a later question or page. People who select any other answer will continue to question %{continue_to_question_number}.<p>"
     delete:
+      exit_pages_heading:
+        one: Question %{question_number} has an exit page
+        other: Question %{question_number} has exit pages
+      exit_pages_html: |
+        <p class="govuk-body">
+          If you delete this question, its %{exit_pages} will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+        </p>
       goto_heading:
         one: There’s a route to question %{question_number}
         other: There are routes to question %{question_number}
@@ -1930,20 +1937,15 @@ en:
       routing_and_goto_heading: There are routes to and from question %{question_number}
       routing_and_goto_html: |
         <p class="govuk-body">
-          If you delete this question, its routes will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+          If you delete this question, its %{routes_and_exit_pages} will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
         </p>
       routing_heading:
         one: Question %{question_number} has a route
         other: Question %{question_number} has routes
-      routing_html:
-        one: |
-          <p class="govuk-body">
-            If you delete this question, its route will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
-          </p>
-        other: |
-          <p class="govuk-body">
-            If you delete this question, its routes will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
-          </p>
+      routing_html: |
+        <p class="govuk-body">
+          If you delete this question, its %{routes_and_exit_pages} will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+        </p>
       title: Are you sure you want to delete this question?
     delete_question: Delete question
     destroy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2413,9 +2413,7 @@ en:
     not_started: Not started
     optional: Optional
   type_of_answer:
-    routing_warning_changing_from_one_option_heading:
-      one: If you change the answer type of this question, its route will be deleted
-      other: If you change the answer type of this question, its routes will be deleted
+    routing_warning_changing_from_one_option_heading: If you change the answer type of this question, its %{routes_and_exit_pages} will be deleted
   unarchive:
     new:
       body_html: |

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -180,4 +180,133 @@ RSpec.describe PagesHelper, type: :helper do
       end
     end
   end
+
+  describe "#routes_and_exit_pages" do
+    subject(:routes_and_exit_pages) { helper.routes_and_exit_pages(page) }
+
+    let(:page) { build_stubbed :page, routing_conditions:, goto_conditions:, exit_pages: }
+    let(:routing_conditions) { [] }
+    let(:goto_conditions) { [] }
+    let(:exit_pages) { [] }
+
+    context "when page has no routes and no exit pages" do
+      let(:routing_conditions) { [] }
+      let(:exit_pages) { [] }
+
+      it { is_expected.to eq "" }
+    end
+
+    context "when page has one route and no exit pages" do
+      let(:routing_conditions) { [build_stubbed(:condition)] }
+      let(:exit_pages) { [] }
+
+      it { is_expected.to eq "route" }
+    end
+
+    context "when page has multiple routes and no exit pages" do
+      let(:routing_conditions) { build_stubbed_list(:condition, 2) }
+      let(:exit_pages) { [] }
+
+      it { is_expected.to eq "routes" }
+    end
+
+    context "when page has no routes and one exit page" do
+      let(:routing_conditions) { [] }
+      let(:exit_pages) { [build_stubbed(:exit_page)] }
+
+      it { is_expected.to eq "exit page" }
+    end
+
+    context "when page has no routes and multiple exit pages" do
+      let(:routing_conditions) { [] }
+      let(:exit_pages) { build_stubbed_list(:exit_page, 2) }
+
+      it { is_expected.to eq "exit pages" }
+    end
+
+    context "when page has one route and one exit page" do
+      let(:routing_conditions) { [build_stubbed(:condition)] }
+      let(:exit_pages) { [build_stubbed(:exit_page)] }
+
+      it { is_expected.to eq "route and exit page" }
+    end
+
+    context "when page has multiple routes and one exit page" do
+      let(:routing_conditions) { build_stubbed_list(:condition, 2) }
+      let(:exit_pages) { [build_stubbed(:exit_page)] }
+
+      it { is_expected.to eq "routes and exit page" }
+    end
+
+    context "when page has multiple routes and multiple exit pages" do
+      let(:routing_conditions) { build_stubbed_list(:condition, 2) }
+      let(:exit_pages) { build_stubbed_list(:exit_page, 2) }
+
+      it { is_expected.to eq "routes and exit pages" }
+    end
+
+    context "when count_goto_conditions is false" do
+      subject(:routes_and_exit_pages) { helper.routes_and_exit_pages(page, count_goto_conditions: false) }
+
+      context "when page has no routing conditions and no goto conditions" do
+        let(:routing_conditions) { [] }
+        let(:goto_conditions) { [] }
+
+        it { is_expected.to eq "" }
+      end
+
+      context "when page has no routing conditions and one goto condition" do
+        let(:routing_conditions) { [] }
+        let(:goto_conditions) { [build_stubbed(:condition)] }
+
+        it { is_expected.to eq "" }
+      end
+
+      context "when page has one routing condition and no goto conditions" do
+        let(:routing_conditions) { [build_stubbed(:condition)] }
+        let(:goto_conditions) { [] }
+
+        it { is_expected.to eq "route" }
+      end
+
+      context "when page has one routing condition and one goto condition" do
+        let(:routing_conditions) { [build_stubbed(:condition)] }
+        let(:goto_conditions) { [build_stubbed(:condition)] }
+
+        it { is_expected.to eq "route" }
+      end
+    end
+
+    context "when count_goto_conditions is true" do
+      subject(:routes_and_exit_pages) { helper.routes_and_exit_pages(page, count_goto_conditions: true) }
+
+      context "when page has no routing conditions and no goto conditions" do
+        let(:routing_conditions) { [] }
+        let(:goto_conditions) { [] }
+
+        it { is_expected.to eq "" }
+      end
+
+      context "when page has no routing conditions and one goto condition" do
+        let(:routing_conditions) { [] }
+        let(:goto_conditions) { [build_stubbed(:condition)] }
+
+        it { is_expected.to eq "route" }
+      end
+
+      context "when page has one routing condition and no goto conditions" do
+        let(:routing_conditions) { [build_stubbed(:condition)] }
+        let(:goto_conditions) { [] }
+
+        it { is_expected.to eq "route" }
+      end
+
+      context "when page has one routing condition and one goto condition" do
+        let(:routing_conditions) { [build_stubbed(:condition)] }
+        let(:goto_conditions) { [build_stubbed(:condition)] }
+
+        it { is_expected.to eq "routes" }
+      end
+    end
+  end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -279,6 +279,41 @@ RSpec.describe PagesController, type: :request do
               assert_select "p.govuk-body a", "View your question routes"
             end
           end
+
+          context "and has one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "Question #{page.position} has a route"
+                assert_select "p.govuk-body", /If you delete this question, its route and exit page will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
+            end
+          end
+
+          context "and has more than one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "Question #{page.position} has a route"
+                assert_select "p.govuk-body", /If you delete this question, its route and exit pages will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
+            end
+          end
         end
 
         context "when page to delete is the start of mulltiple routes" do
@@ -296,6 +331,80 @@ RSpec.describe PagesController, type: :request do
               assert_select "*", "Important"
               assert_select "h3", "Question #{page.position} has routes"
               assert_select "p.govuk-body", /If you delete this question, its routes will also be deleted/
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+
+          context "and has one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "Question #{page.position} has routes"
+                assert_select "p.govuk-body", /If you delete this question, its routes and exit page will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
+            end
+          end
+
+          context "and has more than one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "Question #{page.position} has routes"
+                assert_select "p.govuk-body", /If you delete this question, its routes and exit pages will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
+            end
+          end
+        end
+
+        context "when page has no routes but does have one exit page" do
+          let(:page) { pages.first }
+
+          before do
+            create(:exit_page, question_page: page)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "Question #{page.position} has an exit page"
+              assert_select "p.govuk-body", /If you delete this question, its exit page will also be deleted/
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+
+        context "when page has no routes but does have more than one exit page" do
+          let(:page) { pages.first }
+
+          before do
+            create(:exit_page, question_page: page)
+            create(:exit_page, question_page: page)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "Question #{page.position} has exit pages"
+              assert_select "p.govuk-body", /If you delete this question, its exit pages will also be deleted/
               assert_select "p.govuk-body a", "View your question routes"
             end
           end
@@ -356,6 +465,41 @@ RSpec.describe PagesController, type: :request do
               assert_select "h3", "There are routes to and from question #{page.position}"
               assert_select "p.govuk-body", /If you delete this question, its routes will also be deleted./
               assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+
+          context "and has one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "There are routes to and from question #{page.position}"
+                assert_select "p.govuk-body", /If you delete this question, its routes and exit page will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
+            end
+          end
+
+          context "and has more than one exit page" do
+            before do
+              create(:exit_page, question_page: page)
+              create(:exit_page, question_page: page)
+            end
+
+            it "renders a warning about deleting this page" do
+              get delete_page_path(form_id: form.id, page_id: page.id)
+
+              assert_select(".govuk-notification-banner", count: 1) do
+                assert_select "*", "Important"
+                assert_select "h3", "There are routes to and from question #{page.position}"
+                assert_select "p.govuk-body", /If you delete this question, its routes and exit pages will also be deleted/
+                assert_select "p.govuk-body a", "View your question routes"
+              end
             end
           end
         end

--- a/spec/views/pages/selection/type.html.erb_spec.rb
+++ b/spec/views/pages/selection/type.html.erb_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 describe "pages/selection/type.html.erb", type: :view do
-  let(:form) { create :form }
-  let(:page) { build :page, routing_conditions: }
+  let(:form) { create :form, pages: [page] }
+  let(:page) { build :page, routing_conditions:, exit_pages: }
   let(:page_number) { 1 }
   let(:back_link_url) { "/a-back-link-url" }
   let(:selection_type_path) { "/a-path" }
   let(:only_one_option) { "true" }
   let(:draft_question) { build :draft_question, answer_type: "selection" }
   let(:routing_conditions) { [] }
+  let(:exit_pages) { [] }
   let(:selection_type_input) { Pages::Selection::TypeInput.new(only_one_option:, draft_question:) }
 
   before do
@@ -91,7 +92,23 @@ describe "pages/selection/type.html.erb", type: :view do
 
             context "when show_routing_warning returns true" do
               it "displays a warning about routes being deleted" do
-                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning"))
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning", routes_and_exit_pages: "route"))
+              end
+
+              context "with more than one route from options" do
+                let(:routing_conditions) { build_list(:condition, 3) }
+
+                it "displays a warning about routes being deleted" do
+                  expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning", routes_and_exit_pages: "routes"))
+                end
+              end
+
+              context "with one or more exit pages" do
+                let(:exit_pages) { build_list(:exit_page, 3) }
+
+                it "displays a warning about routes and exit pages being deleted" do
+                  expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning", routes_and_exit_pages: "route and exit pages"))
+                end
               end
             end
 
@@ -111,8 +128,67 @@ describe "pages/selection/type.html.erb", type: :view do
             end
 
             it "displays a combined warning about routes being deleted and needing to reduce the options" do
-              expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading"))
+              expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes_and_exit_pages: "route"))
             end
+
+            context "with one or more exit pages" do
+              let(:exit_pages) { build_list(:exit_page, 3) }
+
+              it "displays a combined warning about routes and exit pages being deleted and needing to reduce the options" do
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes_and_exit_pages: "route and exit pages"))
+              end
+            end
+
+            context "with more than one route from options" do
+              let(:routing_conditions) { build_list(:condition, 3) }
+
+              it "displays a combined warning about routes being deleted and needing to reduce the options" do
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes_and_exit_pages: "routes"))
+              end
+
+              context "with one or more exit pages" do
+                let(:exit_pages) { build_list(:exit_page, 3) }
+
+                it "displays a combined warning about routes and exit pages being deleted and needing to reduce the options" do
+                  expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_and_reduce_your_options_combined_warning.heading", routes_and_exit_pages: "routes and exit pages"))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe "exit pages warning" do
+      context "when question has no routes" do
+        context "and has no exit pages" do
+          it "does not display a warning about exit pages being deleted" do
+            render(template: "pages/selection/type")
+            expect(rendered).not_to have_selector(".govuk-notification-banner")
+          end
+        end
+
+        context "but does have one exit page" do
+          let(:exit_pages) { build_list(:exit_page, 1) }
+
+          it "displays a warning about exit page being deleted" do
+            render(template: "pages/selection/type")
+            expect(rendered).to have_selector(
+              ".govuk-notification-banner__content",
+              text: I18n.t("selection_type.exit_pages_warning", exit_pages: "exit page"),
+            )
+          end
+        end
+
+        context "but does have more than one exit page" do
+          let(:exit_pages) { build_list(:exit_page, 2) }
+
+          it "displays a warning about exit pages being deleted" do
+            render(template: "pages/selection/type")
+            expect(rendered).to have_selector(
+              ".govuk-notification-banner__content",
+              text: I18n.t("selection_type.exit_pages_warning", exit_pages: "exit pages"),
+            )
           end
         end
       end
@@ -136,8 +212,19 @@ describe "pages/selection/type.html.erb", type: :view do
           render(template: "pages/selection/type")
         end
 
-        it "does not display a warning about reducing the number of options" do
+        it "displays a warning about reducing the number of options" do
           expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.reduce_your_options_warning.heading"))
+        end
+
+        context "and the question has one or more exit pages" do
+          let(:exit_pages) { build_list(:exit_page, 3) }
+
+          it "displays a combined warning about exit pages being deleted and needing to reduce the options" do
+            expect(rendered).to have_selector(
+              ".govuk-notification-banner__content",
+              text: I18n.t("selection_type.exit_pages_and_reduce_your_options_combined_warning.heading", exit_pages: "exit pages"),
+            )
+          end
         end
       end
     end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -1,18 +1,15 @@
 require "rails_helper"
 
 describe "pages/type_of_answer.html.erb", type: :view do
-  let(:form) { create :form, :with_group }
+  let(:form) { create :form, :with_group, pages: [page] }
   let(:type_of_answer_input) { build :type_of_answer_input }
-  let(:page) { OpenStruct.new(routing_conditions: [], answer_type: "number") }
+  let(:page) { build(:page, position: question_number) }
   let(:question_number) { 1 }
   let(:is_new_page) { true }
 
   before do
     # allow objects to use ids in form helper
     allow(type_of_answer_input).to receive(:persisted?).and_return(true)
-
-    # mock the form.page_number method
-    allow(form).to receive_messages(persisted?: true, page_number: question_number)
 
     without_partial_double_verification do
       allow(view).to receive_messages(current_form: form)
@@ -67,10 +64,8 @@ describe "pages/type_of_answer.html.erb", type: :view do
   end
 
   context "when editing an existing select one option question with a route set" do
-    let(:page) { OpenStruct.new(routing_conditions:, answer_type:, answer_settings:) }
-    let(:answer_settings) { OpenStruct.new(only_one_option: "true") }
-    let(:answer_type) { "selection" }
-    let(:routing_conditions) { [build(:condition)] }
+    let(:page) { build(:page, :with_selection_settings, routing_conditions:) }
+    let(:routing_conditions) { [build(:condition, answer_value: "Option 1")] }
 
     it "displays a warning about routes being deleted if answer type changes" do
       expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
@@ -79,7 +74,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
     end
 
     context "with multiple routes set" do
-      let(:routing_conditions) { [build(:condition), build(:condition)] }
+      let(:routing_conditions) { [build(:condition, answer_value: "Option 1"), build(:condition, answer_value: "Option 2")] }
 
       it "displays a warning about routes being deleted if answer type changes" do
         expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -90,5 +90,36 @@ describe "pages/type_of_answer.html.erb", type: :view do
         expect(rendered).not_to have_selector(".govuk-notification-banner__content")
       end
     end
+
+    context "with more than 10 selection options" do
+      let(:page) { build(:page, :with_selection_settings, routing_conditions:, selection_options:) }
+      let(:selection_options) { (1..11).map { |n| DataStruct.new(name: "Option #{n}", value: "Option #{n}") } }
+
+      context "and no routing conditions" do
+        let(:routing_conditions) { [] }
+
+        it "does not display a warning about routes being deleted if answer type changes" do
+          expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+        end
+      end
+
+      context "and an unconditional route" do
+        let(:routing_conditions) { [build(:condition, answer_value: nil)] }
+
+        it "does not display a warning about routes being deleted if answer type changes" do
+          expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+        end
+      end
+
+      context "and a route for a selection option" do
+        let(:routing_conditions) { [build(:condition, answer_value: "Option 1")] }
+
+        it "displays a warning about routes being deleted if answer type changes" do
+          expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
+            .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 1))
+              .text(normalize_ws: true))
+        end
+      end
+    end
   end
 end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -63,14 +63,19 @@ describe "pages/type_of_answer.html.erb", type: :view do
     expect(rendered).not_to have_selector(".govuk-notification-banner__content")
   end
 
-  context "when editing an existing select one option question with a route set" do
-    let(:page) { build(:page, :with_selection_settings, routing_conditions:) }
-    let(:routing_conditions) { [build(:condition, answer_value: "Option 1")] }
+  context "when editing an existing select one option question" do
+    let(:page) { build(:page, :with_selection_settings, routing_conditions:, exit_pages:) }
+    let(:routing_conditions) { [] }
+    let(:exit_pages) { [] }
 
-    it "displays a warning about routes being deleted if answer type changes" do
-      expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
-        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 1))
-          .text(normalize_ws: true))
+    context "with a routing condition" do
+      let(:routing_conditions) { [build(:condition, answer_value: "Option 1")] }
+
+      it "displays a warning about routes being deleted if answer type changes" do
+        expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
+          .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", routes_and_exit_pages: "route"))
+            .text(normalize_ws: true))
+      end
     end
 
     context "with multiple routes set" do
@@ -78,7 +83,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
 
       it "displays a warning about routes being deleted if answer type changes" do
         expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
-          .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 2))
+          .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", routes_and_exit_pages: "routes"))
             .text(normalize_ws: true))
       end
     end
@@ -116,9 +121,20 @@ describe "pages/type_of_answer.html.erb", type: :view do
 
         it "displays a warning about routes being deleted if answer type changes" do
           expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
-            .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 1))
+            .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", routes_and_exit_pages: "route"))
               .text(normalize_ws: true))
         end
+      end
+    end
+
+    context "with an exit page" do
+      let(:exit_pages) { build_list(:exit_page, 1) }
+
+      it "displays a warning about exit pages being deleted if answer type changes" do
+        expect(rendered).to have_selector(
+          ".govuk-notification-banner__content",
+          text: t("type_of_answer.routing_warning_changing_from_one_option_heading", routes_and_exit_pages: "exit page"),
+        )
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/47FSoncs/3166-update-warning-messages-for-exit-pages-for-multiple-branches <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update content for notification banners to warn form creators when an exit page might be deleted.

These changes should work with new-style and old-style exit pages (as well as the current journey to add routes and the edit routes page), so these changes don't need to be behind a feature flag.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
