### PR TITLE
Validate contents of welsh csv upload

### DIFF
--- a/app/input_objects/forms/welsh_translation_upload_input.rb
+++ b/app/input_objects/forms/welsh_translation_upload_input.rb
@@ -22,6 +22,15 @@ class Forms::WelshTranslationUploadInput < BaseInput
   rescue WelshCsvImportService::InvalidHeadersError
     errors.add(:file, :invalid_headers)
     false
+  rescue WelshCsvImportService::DifferentNumberOfSelectionOptionsError => e
+    errors.add(:file, :different_number_of_selection_options, question_number: e.question_number)
+    false
+  rescue WelshCsvImportService::SelectionOptionsMismatchError => e
+    errors.add(:file, :selection_options_mismatch, question_number: e.question_number)
+    false
+  rescue WelshCsvImportService::SelectionOptionTranslationsMissingError => e
+    errors.add(:file, :selection_options_translations_missing, question_number: e.question_number)
+    false
   end
 
 private

--- a/app/input_objects/forms/welsh_translation_upload_input.rb
+++ b/app/input_objects/forms/welsh_translation_upload_input.rb
@@ -1,10 +1,14 @@
 class Forms::WelshTranslationUploadInput < BaseInput
+  include ActiveModel::Attributes
+
   FILE_TYPES = %w[
     text/csv
   ].freeze
   MAX_SIZE_IN_MB = 10
 
   attr_accessor :form, :file
+
+  attribute :error_row_number
 
   validates :file, presence: true, file_content_type: { in: FILE_TYPES }
   validate :validate_file_size
@@ -30,6 +34,19 @@ class Forms::WelshTranslationUploadInput < BaseInput
     false
   rescue WelshCsvImportService::SelectionOptionTranslationsMissingError => e
     errors.add(:file, :selection_options_translations_missing, question_number: e.question_number)
+    false
+  rescue WelshCsvImportService::FormContentNotFoundError => e
+    errors.add(:file, :form_content_not_found)
+    self.error_row_number = e.row_number
+    false
+  rescue WelshCsvImportService::QuestionTextMismatchError => e
+    # the error message is the same as for form_content_not_found, but we use a separate key to distinguish in the logs
+    errors.add(:file, :question_text_mismatch)
+    self.error_row_number = e.row_number
+    false
+  rescue WelshCsvImportService::ExitPageHeadingMismatchError => e
+    errors.add(:file, :exit_page_heading_mismatch)
+    self.error_row_number = e.row_number
     false
   end
 

--- a/app/lib/welsh_translation_content_labels.rb
+++ b/app/lib/welsh_translation_content_labels.rb
@@ -53,6 +53,14 @@ module WelshTranslationContentLabels
     label.to_s.match?(/^Question \d+ - option \d+$/)
   end
 
+  def is_question_text?(label)
+    label.match?(/^Question \d+ - #{PAGE_ATTRIBUTE_LABELS[:question_text]}$/)
+  end
+
+  def is_exit_page_heading?(label)
+    label.match?(/^Question \d+ - exit page (\d+ )?heading$/)
+  end
+
   def question_number_from_label(label)
     /^Question (\d+)/.match(label)&.[](1)&.to_i
   end

--- a/app/lib/welsh_translation_content_labels.rb
+++ b/app/lib/welsh_translation_content_labels.rb
@@ -54,11 +54,11 @@ module WelshTranslationContentLabels
   end
 
   def is_question_text?(label)
-    label.match?(/^Question \d+ - #{PAGE_ATTRIBUTE_LABELS[:question_text]}$/)
+    label.to_s.match?(/^Question \d+ - #{PAGE_ATTRIBUTE_LABELS[:question_text]}$/)
   end
 
   def is_exit_page_heading?(label)
-    label.match?(/^Question \d+ - exit page (\d+ )?heading$/)
+    label.to_s.match?(/^Question \d+ - exit page (\d+ )?heading$/)
   end
 
   def question_number_from_label(label)

--- a/app/lib/welsh_translation_content_labels.rb
+++ b/app/lib/welsh_translation_content_labels.rb
@@ -48,4 +48,12 @@ module WelshTranslationContentLabels
   def question_name(page)
     "Question #{page.position}"
   end
+
+  def is_selection_option?(label)
+    label.to_s.match?(/^Question \d+ - option \d+$/)
+  end
+
+  def question_number_from_label(label)
+    /^Question (\d+)/.match(label)&.[](1)&.to_i
+  end
 end

--- a/app/services/welsh_csv_import_service.rb
+++ b/app/services/welsh_csv_import_service.rb
@@ -17,6 +17,19 @@ class WelshCsvImportService
   class SelectionOptionsMismatchError < QuestionError; end
   class SelectionOptionTranslationsMissingError < QuestionError; end
 
+  class MismatchWithCurrentFormError < StandardError
+    attr_reader :row_number
+
+    def initialize(message, row_number)
+      super(message)
+      @row_number = row_number
+    end
+  end
+
+  class FormContentNotFoundError < MismatchWithCurrentFormError; end
+  class QuestionTextMismatchError < MismatchWithCurrentFormError; end
+  class ExitPageHeadingMismatchError < MismatchWithCurrentFormError; end
+
   attr_reader :file
 
   HEADER_INDEXES = {
@@ -40,6 +53,7 @@ class WelshCsvImportService
     raise InvalidHeadersError unless headers_valid?(csv)
 
     validate_selection_question_options!(csv)
+    validate_matches_current_form!(csv)
 
     csv.each_with_object({}) do |row, values|
       content_id = row[WelshCsvService::CONTENT_ID_HEADER]
@@ -83,8 +97,43 @@ private
     end
   end
 
+  def validate_matches_current_form!(csv)
+    # Check question text and exit page heading English content matches the current form,
+    # to avoid applying translations to the wrong question or exit page if the order has changed.
+    csv.each_with_index do |row, index|
+      content_id = row[content_id_column]
+      current_english = current_form_english_by_content_id[content_id]
+
+      row_number = index + 2 # accounts for header row
+
+      if current_english.nil?
+        raise FormContentNotFoundError.new(
+          "Content ID is not present for the current form: \"#{content_id}\"", row_number
+        )
+      end
+
+      if is_question_text?(content_id) && row[english_column] != current_english
+        raise QuestionTextMismatchError.new(
+          "The question text does not have the same English content as the current form", row_number
+        )
+      end
+
+      next unless is_exit_page_heading?(content_id) && row[english_column] != current_english
+
+      raise ExitPageHeadingMismatchError.new(
+        "The exit page heading does not have the same English content as the current form", row_number
+      )
+    end
+  end
+
   def current_form_state_csv
     @current_form_state_csv ||= CSV.parse(WelshCsvService.new(@form).as_csv(include_bom: false), headers: true)
+  end
+
+  def current_form_english_by_content_id
+    @current_form_english_by_content_id ||= current_form_state_csv.each_with_object({}) do |row, hash|
+      hash[row[content_id_column]] = row[english_column]
+    end
   end
 
   def selection_option_rows_by_question(csv)
@@ -96,12 +145,22 @@ private
   end
 
   def english_values(rows)
-    column = HEADER_INDEXES[WelshCsvService::ENGLISH_CONTENT_HEADER]
-    rows.map { |row| row[column] }
+    rows.map { |row| row[english_column] }
   end
 
   def welsh_values(rows)
-    column = HEADER_INDEXES[WelshCsvService::WELSH_CONTENT_HEADER]
-    rows.map { |row| row[column] }
+    rows.map { |row| row[welsh_column] }
+  end
+
+  def content_id_column
+    HEADER_INDEXES[WelshCsvService::CONTENT_ID_HEADER]
+  end
+
+  def english_column
+    HEADER_INDEXES[WelshCsvService::ENGLISH_CONTENT_HEADER]
+  end
+
+  def welsh_column
+    HEADER_INDEXES[WelshCsvService::WELSH_CONTENT_HEADER]
   end
 end

--- a/app/services/welsh_csv_import_service.rb
+++ b/app/services/welsh_csv_import_service.rb
@@ -4,6 +4,19 @@ class WelshCsvImportService
   class InvalidHeadersError < StandardError; end
   class InvalidEncodingError < StandardError; end
 
+  class QuestionError < StandardError
+    attr_reader :question_number
+
+    def initialize(message, question_number)
+      super(message)
+      @question_number = question_number
+    end
+  end
+
+  class DifferentNumberOfSelectionOptionsError < QuestionError; end
+  class SelectionOptionsMismatchError < QuestionError; end
+  class SelectionOptionTranslationsMissingError < QuestionError; end
+
   attr_reader :file
 
   HEADER_INDEXES = {
@@ -26,6 +39,8 @@ class WelshCsvImportService
 
     raise InvalidHeadersError unless headers_valid?(csv)
 
+    validate_selection_question_options!(csv)
+
     csv.each_with_object({}) do |row, values|
       content_id = row[WelshCsvService::CONTENT_ID_HEADER]
       next if content_id.nil?
@@ -40,5 +55,53 @@ private
     HEADER_INDEXES.all? do |header, index|
       csv.headers[index] == header
     end
+  end
+
+  def validate_selection_question_options!(csv)
+    current_form_rows_by_question = selection_option_rows_by_question(current_form_state_csv)
+
+    selection_option_rows_by_question(csv).each do |question_number, selection_option_rows|
+      current_form_rows = current_form_rows_by_question[question_number] || []
+
+      if selection_option_rows.size != current_form_rows.size
+        raise DifferentNumberOfSelectionOptionsError.new(
+          "Number of selection options does not match the form", question_number
+        )
+      end
+
+      if english_values(selection_option_rows) != english_values(current_form_rows)
+        raise SelectionOptionsMismatchError.new("Selection options do not match the form", question_number)
+      end
+
+      welsh_values = welsh_values(selection_option_rows)
+      # Raise if translations have been provided for some selection options, but not all
+      next unless welsh_values.any?(&:present?) && welsh_values.any?(&:blank?)
+
+      raise SelectionOptionTranslationsMissingError.new(
+        "Selection options are missing translations", question_number
+      )
+    end
+  end
+
+  def current_form_state_csv
+    @current_form_state_csv ||= CSV.parse(WelshCsvService.new(@form).as_csv(include_bom: false), headers: true)
+  end
+
+  def selection_option_rows_by_question(csv)
+    content_id_column = HEADER_INDEXES[WelshCsvService::CONTENT_ID_HEADER]
+    csv.to_a
+       .select { |row| is_selection_option?(row[content_id_column]) }
+       .group_by { |row| question_number_from_label(row[content_id_column]) }
+       .reject { |question_number, _| question_number.nil? }
+  end
+
+  def english_values(rows)
+    column = HEADER_INDEXES[WelshCsvService::ENGLISH_CONTENT_HEADER]
+    rows.map { |row| row[column] }
+  end
+
+  def welsh_values(rows)
+    column = HEADER_INDEXES[WelshCsvService::WELSH_CONTENT_HEADER]
+    rows.map { |row| row[column] }
   end
 end

--- a/app/services/welsh_csv_service.rb
+++ b/app/services/welsh_csv_service.rb
@@ -15,7 +15,7 @@ class WelshCsvService
     @form = form
   end
 
-  def as_csv
+  def as_csv(include_bom: true)
     csv = CSV.generate do |csv|
       add_header(csv)
       add_form_name(csv)
@@ -24,7 +24,7 @@ class WelshCsvService
     end
 
     # Prepend UTF-8 BOM so Excel recognises the file as UTF-8 and preserves special characters
-    "#{UTF_8_BOM}#{csv}"
+    "#{UTF_8_BOM if include_bom}#{csv}"
   end
 
   def filename

--- a/app/views/forms/welsh_translation/show_upload.html.erb
+++ b/app/views/forms/welsh_translation/show_upload.html.erb
@@ -5,7 +5,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: welsh_translation_upload_input, url: welsh_translation_upload_path(current_form), method: 'POST') do |f| %>
       <% if welsh_translation_upload_input&.errors.any? %>
-        <%= f.govuk_error_summary %>
+        <% if welsh_translation_upload_input.error_row_number %>
+          <%= f.govuk_error_summary(t(".error_summary_title_with_row_number", row_number: welsh_translation_upload_input.error_row_number)) %>
+        <% else %>
+          <%= f.govuk_error_summary %>
+        <% end %>
       <% end %>
 
       <h1 class="govuk-heading-l">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -753,6 +753,7 @@ en:
         support_url_text: Text to describe the contact link
         welsh_header: Welsh content
       show_upload:
+        error_summary_title_with_row_number: There is a problem from row %{row_number} onwards in the CSV
         warning: This will replace any Welsh content you already have saved in the form
   group_forms:
     edit:

--- a/config/locales/input_objects/welsh_translation_upload.yml
+++ b/config/locales/input_objects/welsh_translation_upload.yml
@@ -8,12 +8,15 @@ en:
             file:
               blank: Select a file
               different_number_of_selection_options: There’s a different number of options for the English and Welsh versions of Question %{question_number} - try downloading a new CSV of the existing content, then uploading it again
+              exit_page_heading_mismatch: It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again
+              form_content_not_found: It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again
               invalid_encoding: File is not in CSV UTF-8 format - in Excel, go to ‘File’ then ‘Save as’
               invalid_file_type: The selected file must be a CSV
               invalid_headers: We couldn’t upload the CSV because the column headings are wrong - check them and try uploading again
               malformed: The CSV has invalid formatting - try downloading a new version, then uploading it again
-              selection_options_translations_missing: Question %{question_number} is missing Welsh translations for one or more options - add them, then try uploading the CSV again
+              question_text_mismatch: It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again
               selection_options_mismatch: For the list options in question %{question_number}, the English and Welsh versions do not match - try downloading a new CSV of the existing content, then uploading it again
+              selection_options_translations_missing: Question %{question_number} is missing Welsh translations for one or more options - add them, then try uploading the CSV again
               too_big: The selected file must be smaller than 10MB
   helpers:
     hint:

--- a/config/locales/input_objects/welsh_translation_upload.yml
+++ b/config/locales/input_objects/welsh_translation_upload.yml
@@ -7,10 +7,13 @@ en:
           attributes:
             file:
               blank: Select a file
+              different_number_of_selection_options: There’s a different number of options for the English and Welsh versions of Question %{question_number} - try downloading a new CSV of the existing content, then uploading it again
               invalid_encoding: File is not in CSV UTF-8 format - in Excel, go to ‘File’ then ‘Save as’
               invalid_file_type: The selected file must be a CSV
               invalid_headers: We couldn’t upload the CSV because the column headings are wrong - check them and try uploading again
               malformed: The CSV has invalid formatting - try downloading a new version, then uploading it again
+              selection_options_translations_missing: Question %{question_number} is missing Welsh translations for one or more options - add them, then try uploading the CSV again
+              selection_options_mismatch: For the list options in question %{question_number}, the English and Welsh versions do not match - try downloading a new CSV of the existing content, then uploading it again
               too_big: The selected file must be smaller than 10MB
   helpers:
     hint:

--- a/spec/input_objects/forms/welsh_translation_upload_input_spec.rb
+++ b/spec/input_objects/forms/welsh_translation_upload_input_spec.rb
@@ -144,5 +144,47 @@ RSpec.describe Forms::WelshTranslationUploadInput do
         expect(input.errors.full_messages_for(:file)).to include("File Question 2 is missing Welsh translations for one or more options - add them, then try uploading the CSV again")
       end
     end
+
+    context "when a FormContentNotFoundError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::FormContentNotFoundError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors).to be_of_kind(:file, :form_content_not_found)
+        expect(input.errors.full_messages_for(:file)).to include("File It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again")
+        expect(input.error_row_number).to eq 2
+      end
+    end
+
+    context "when a QuestionTextMismatchError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::QuestionTextMismatchError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors).to be_of_kind(:file, :question_text_mismatch)
+        expect(input.errors.full_messages_for(:file)).to include("File It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again")
+        expect(input.error_row_number).to eq 2
+      end
+    end
+
+    context "when a ExitPageHeadingMismatchError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::ExitPageHeadingMismatchError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors).to be_of_kind(:file, :exit_page_heading_mismatch)
+        expect(input.errors.full_messages_for(:file)).to include("File It looks like the form has changed since you downloaded the CSV of existing content - try downloading a new version, then uploading it again")
+        expect(input.error_row_number).to eq 2
+      end
+    end
   end
 end

--- a/spec/input_objects/forms/welsh_translation_upload_input_spec.rb
+++ b/spec/input_objects/forms/welsh_translation_upload_input_spec.rb
@@ -108,5 +108,41 @@ RSpec.describe Forms::WelshTranslationUploadInput do
         expect(input.errors.full_messages_for(:file)).to include("File We couldn’t upload the CSV because the column headings are wrong - check them and try uploading again")
       end
     end
+
+    context "when a DifferentNumberOfSelectionOptionsError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::DifferentNumberOfSelectionOptionsError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors.full_messages_for(:file)).to include("File There’s a different number of options for the English and Welsh versions of Question 2 - try downloading a new CSV of the existing content, then uploading it again")
+      end
+    end
+
+    context "when a SelectionOptionsMismatchError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::SelectionOptionsMismatchError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors.full_messages_for(:file)).to include("File For the list options in question 2, the English and Welsh versions do not match - try downloading a new CSV of the existing content, then uploading it again")
+      end
+    end
+
+    context "when a SelectionOptionTranslationsMissingError is raised" do
+      before do
+        allow(mock_welsh_csv_import_service).to receive(:read).and_raise(WelshCsvImportService::SelectionOptionTranslationsMissingError.new("An error", 2))
+      end
+
+      it "returns false and adds an error" do
+        input = described_class.new(form: form, file: file)
+        expect(input.read_file).to be false
+        expect(input.errors.full_messages_for(:file)).to include("File Question 2 is missing Welsh translations for one or more options - add them, then try uploading the CSV again")
+      end
+    end
   end
 end

--- a/spec/lib/welsh_translation_content_labels_spec.rb
+++ b/spec/lib/welsh_translation_content_labels_spec.rb
@@ -13,6 +13,34 @@ RSpec.describe WelshTranslationContentLabels do
     end
   end
 
+  describe "#is_question_text?" do
+    it "returns true for a question text label" do
+      expect(helper.is_question_text?("Question 1 - question text")).to be true
+    end
+
+    it "returns false for a hint text label" do
+      expect(helper.is_question_text?("Question 1 - hint text")).to be false
+    end
+  end
+
+  describe "#is_exit_page_heading?" do
+    it "returns true for a condition-style exit page heading label" do
+      expect(helper.is_exit_page_heading?("Question 1 - exit page heading")).to be true
+    end
+
+    it "returns true for a numbered exit page heading label" do
+      expect(helper.is_exit_page_heading?("Question 1 - exit page 2 heading")).to be true
+    end
+
+    it "returns false for an exit page content label" do
+      expect(helper.is_exit_page_heading?("Question 1 - exit page content")).to be false
+    end
+
+    it "returns false for a question text label" do
+      expect(helper.is_exit_page_heading?("Question 1 - question text")).to be false
+    end
+  end
+
   describe "#question_number_from_label" do
     it "returns the question number from a question text label" do
       expect(helper.question_number_from_label("Question 3 - question text")).to eq(3)

--- a/spec/lib/welsh_translation_content_labels_spec.rb
+++ b/spec/lib/welsh_translation_content_labels_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe WelshTranslationContentLabels do
+  subject(:helper) { Class.new { include WelshTranslationContentLabels }.new }
+
+  describe "#is_selection_option?" do
+    it "returns true for a valid selection option label" do
+      expect(helper.is_selection_option?("Question 1 - option 1")).to be true
+    end
+
+    it "returns false for a question text label" do
+      expect(helper.is_selection_option?("Question 1 - question text")).to be false
+    end
+  end
+
+  describe "#question_number_from_label" do
+    it "returns the question number from a question text label" do
+      expect(helper.question_number_from_label("Question 3 - question text")).to eq(3)
+    end
+
+    it "returns the question number from a selection option label" do
+      expect(helper.question_number_from_label("Question 12 - option 2")).to eq(12)
+    end
+
+    it "returns nil for a label with no question number" do
+      expect(helper.question_number_from_label("Form name")).to be_nil
+    end
+  end
+end

--- a/spec/requests/forms/welsh_translation_controller_spec.rb
+++ b/spec/requests/forms/welsh_translation_controller_spec.rb
@@ -462,6 +462,9 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
     end
 
     context "when a valid CSV is uploaded" do
+      let(:form) { create(:form, :with_pages, pages: [page]) }
+      let(:page) { create(:page, :with_selection_settings, question_text: "Are you eligible?") }
+
       context "when the multiple branches feature is disabled", feature_multiple_branches: false do
         let(:condition) do
           create(:condition, routing_page: form.pages.first, answer_value: "No",
@@ -473,6 +476,9 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
           CSV.generate do |csv|
             csv << ["Content ID", "English content", "Welsh content"]
             csv << ["Form name", form.name, "Fy Ffurflen"]
+            csv << ["Question 1 - question text", "Are you eligible?", "Welsh question text"]
+            csv << ["Question 1 - option 1", "Option 1", "Welsh Option 1"]
+            csv << ["Question 1 - option 2", "Option 2", "Welsh Option 2"]
             csv << ["Question 1 - exit page heading", "You are ineligible", "Welsh exit page heading"]
             csv << ["Question 1 - exit page content", "Sorry, you are ineligible for this service.", "Welsh exit page content"]
           end
@@ -513,12 +519,15 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
       end
 
       context "when the multiple branches feature is enabled", :feature_multiple_branches do
-        let(:exit_page) { create :exit_page, question_page: form.pages.first }
+        let(:exit_page) { create :exit_page, question_page: form.pages.first, heading: "You are ineligible" }
 
         let(:csv_data) do
           CSV.generate do |csv|
             csv << ["Content ID", "English content", "Welsh content"]
             csv << ["Form name", form.name, "Fy Ffurflen"]
+            csv << ["Question 1 - question text", "Are you eligible?", "Welsh question text"]
+            csv << ["Question 1 - option 1", "Option 1", "Welsh Option 1"]
+            csv << ["Question 1 - option 2", "Option 2", "Welsh Option 2"]
             csv << ["Question 1 - exit page 1 heading", "You are ineligible", "Welsh exit page heading"]
             csv << ["Question 1 - exit page 1 content", "Sorry, you are ineligible for this service.", "Welsh exit page content"]
           end

--- a/spec/services/welsh_csv_import_service_spec.rb
+++ b/spec/services/welsh_csv_import_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WelshCsvImportService do
            support_phone: "English support phone",
            support_url: "https://www.gov.uk/support",
            support_url_text: "Support URL text",
-           declaration_text: "Declaration text",
+           declaration_markdown: "You are agreeing to some things",
            pages: [page, another_page]
   end
   let(:page) do
@@ -34,7 +34,7 @@ RSpec.describe WelshCsvImportService do
     file.unlink
   end
 
-  context "when the CSV is valid" do
+  context "when the CSV format is valid" do
     context "when the rows in the CSV match the current form" do
       let(:bom) { "" }
 
@@ -51,7 +51,7 @@ RSpec.describe WelshCsvImportService do
           ["Question 2 - page heading", "Page heading", "Welsh Page heading"],
           ["Question 2 - guidance text", "This is the guidance.", "Welsh This is the guidance."],
           ["Question 2 - question text", "What?", "Welsh What?"],
-          ["Declaration", "Declaration text", "Welsh declaration text"],
+          ["Declaration", "You are agreeing to some things", "Welsh declaration text"],
           ["Information about what happens next", "English what happens next", "Welsh what happens next"],
           ["GOV.UK Pay payment link", "https://www.gov.uk/payment", "https://www.gov.uk/payment_cy"],
           ["Link to privacy information for this form", "https://www.gov.uk/privacy", "https://www.gov.uk/privacy_cy"],
@@ -95,20 +95,11 @@ RSpec.describe WelshCsvImportService do
         end
       end
     end
-  end
-
-  context "when the CSV is not UTF-8 encoded" do
-    before do
-      file.binmode
-      file.write("Content ID,English content,Welsh content\r\nForm name,A form,caf\xE9\r\n".b)
-      file.rewind
-    end
-
-    it "raises an InvalidEncodingError" do
-      expect { service.read }.to raise_error(WelshCsvImportService::InvalidEncodingError)
-    end
 
     describe "selection option questions validation" do
+      let(:form) { create :form, :new_form, :with_group, :with_pages, name: "A form", pages: [page] }
+      let(:page) { create :page, :selection_with_checkboxes, question_text: "Pick an option" }
+
       context "when a selection question has fewer options in the CSV than in the form" do
         before do
           rows = [
@@ -210,6 +201,146 @@ RSpec.describe WelshCsvImportService do
           expect { service.read }.not_to raise_error
         end
       end
+    end
+
+    describe "validation against current form structure" do
+      let(:page) { create :page, :with_text_settings, question_text: "What colour is the sky?" }
+      let(:another_page) { create :page, :with_text_settings, question_text: "How old are you?" }
+
+      context "when the question order is different in the CSV" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "How old are you?", "Welsh How old are you?"],
+            ["Question 2 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a QuestionTextMismatchError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::QuestionTextMismatchError) do |e|
+            expect(e.row_number).to eq(3)
+          end
+        end
+      end
+
+      context "when the uploaded CSV is missing rows for some question attributes" do
+        let(:another_page) { create :page, :with_text_settings, :with_guidance, question_text: "How old are you?" }
+
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+            # the page heading and guidance rows are omitted
+            ["Question 2 - question text", "How old are you?", "Welsh How old are you?"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "does not raise an error" do
+          expect { service.read }.not_to raise_error
+        end
+      end
+
+      context "when there are fewer questions in the CSV than in the form" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+            ["Declaration", "Declaration text", "Welsh declaration text"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "does not raise an error" do
+          expect { service.read }.not_to raise_error
+        end
+      end
+
+      context "when there is a Content ID in the CSV that do not exist for the form" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+            ["Question 2 - question text", "How old are you?", "Welsh How old are you?"],
+            ["Question 3 - question text", "This question doesn't exist in the form", "Welsh for this"],
+            ["Declaration", "Declaration text", "Welsh declaration text"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a FormContentNotFoundError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::FormContentNotFoundError) do |e|
+            expect(e.message).to eq("Content ID is not present for the current form: \"Question 3 - question text\"")
+            expect(e.row_number).to eq(5)
+          end
+        end
+      end
+
+      context "when an exit page heading in the CSV does not match the current form" do
+        let(:page) do
+          create :page, :with_text_settings, question_text: "What colour is the sky?",
+                                             routing_conditions: [create(:condition, :with_exit_page, exit_page_heading: "Exit page heading")]
+        end
+
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+            ["Question 1 - exit page heading", "WRONG HEADING", "Welsh exit page heading"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a ExitPageHeadingMismatchError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::ExitPageHeadingMismatchError) do |e|
+            expect(e.row_number).to eq(4)
+          end
+        end
+      end
+
+      context "when the rows in the uploaded CSV match the current form but some rows are missing" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form ôÂŵéï"],
+            ["Question 1 - question text", "What colour is the sky?", "Welsh What colour is the sky?"],
+            ["Question 2 - question text", "How old are you?", "Welsh How old are you?"],
+            ["Declaration", "Declaration text", "Welsh declaration text"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "does not raise an error" do
+          expect { service.read }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  context "when the CSV is not UTF-8 encoded" do
+    before do
+      file.binmode
+      file.write("Content ID,English content,Welsh content\r\nForm name,A form,caf\xE9\r\n".b)
+      file.rewind
+    end
+
+    it "raises an InvalidEncodingError" do
+      expect { service.read }.to raise_error(WelshCsvImportService::InvalidEncodingError)
     end
   end
 

--- a/spec/services/welsh_csv_import_service_spec.rb
+++ b/spec/services/welsh_csv_import_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe WelshCsvImportService do
   let(:form) do
     create :form,
            :with_pages,
+           :with_group,
            name: "A form",
            what_happens_next_markdown: "English what happens next",
            privacy_policy_url: "https://www.gov.uk/privacy",
@@ -105,6 +106,110 @@ RSpec.describe WelshCsvImportService do
 
     it "raises an InvalidEncodingError" do
       expect { service.read }.to raise_error(WelshCsvImportService::InvalidEncodingError)
+    end
+
+    describe "selection option questions validation" do
+      context "when a selection question has fewer options in the CSV than in the form" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form"],
+            ["Question 1 - question text", "Pick an option", "Welsh Pick an option"],
+            ["Question 1 - option 1", "Option 1", "Welsh Option 1"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a DifferentNumberOfSelectionOptionsError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::DifferentNumberOfSelectionOptionsError) do |e|
+            expect(e.question_number).to eq(page.position)
+          end
+        end
+      end
+
+      context "when a selection question has more options in the CSV than in the form" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form"],
+            ["Question 1 - question text", "Pick an option", "Welsh Pick an option"],
+            ["Question 1 - option 1", "Option 1", "Welsh Option 1"],
+            ["Question 1 - option 2", "Option 2", "Welsh Option 2"],
+            ["Question 1 - option 3", "Option 3", "Welsh Option 3"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a DifferentNumberOfSelectionOptionsError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::DifferentNumberOfSelectionOptionsError) do |e|
+            expect(e.question_number).to eq(page.position)
+          end
+        end
+      end
+
+      context "when the English for a selection option in the CSV does not match the form" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form"],
+            ["Question 1 - question text", "Pick an option", "Welsh Pick an option"],
+            ["Question 1 - option 1", "Option 1", "Welsh Option 1"],
+            ["Question 1 - option 2", "NOT THE SAME", "Welsh Option 2"],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a SelectionOptionsMismatchError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::SelectionOptionsMismatchError) do |e|
+            expect(e.question_number).to eq(page.position)
+          end
+        end
+      end
+
+      context "when some selection options are translated but others are not" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form"],
+            ["Question 1 - question text", "Pick an option", "Welsh Pick an option"],
+            ["Question 1 - option 1", "Option 1", "Welsh Option 1"],
+            ["Question 1 - option 2", "Option 2", ""],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "raises a SelectionOptionTranslationsMissingError" do
+          expect { service.read }
+            .to raise_error(WelshCsvImportService::SelectionOptionTranslationsMissingError) do |e|
+            expect(e.question_number).to eq(page.position)
+          end
+        end
+      end
+
+      context "when none of the selection options are translated" do
+        before do
+          rows = [
+            ["Content ID", "English content", "Welsh content"],
+            ["Form name", "A form", "Welsh A form"],
+            ["Question 1 - question text", "Pick an option", "Welsh Pick an option"],
+            ["Question 1 - option 1", "Option 1", ""],
+            ["Question 1 - option 2", "Option 2", ""],
+          ]
+          file.write(rows.map(&:to_csv).join)
+          file.rewind
+        end
+
+        it "does not raise an error" do
+          expect { service.read }.not_to raise_error
+        end
+      end
     end
   end
 

--- a/spec/services/welsh_csv_service_spec.rb
+++ b/spec/services/welsh_csv_service_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe "WelshCsvService", feature_multiple_branches: false do
       expect(csv_rows(form)[0]).to eq(["\uFEFFContent ID", "English content", "Welsh content"])
     end
 
+    it "does not prepend the UTF-8 BOM if include_bom is false" do
+      csv = WelshCsvService.new(form).as_csv(include_bom: false)
+      rows = CSV.parse(csv)
+
+      expect(rows[0]).to eq(["Content ID", "English content", "Welsh content"])
+    end
+
     it "contains the form name" do
       expect(csv_rows(form)).to include([
         "Form name",

--- a/spec/views/forms/welsh_translation/show_upload.html.erb_spec.rb
+++ b/spec/views/forms/welsh_translation/show_upload.html.erb_spec.rb
@@ -49,4 +49,20 @@ describe "forms/welsh_translation/show_upload.html.erb" do
       expect(rendered).to have_css(".govuk-error-message", text: "an error occurred")
     end
   end
+
+  context "when there are errors and an error_row_number is set" do
+    before do
+      welsh_translation_upload_input.errors.add(:file, "an error occurred")
+      welsh_translation_upload_input.error_row_number = 2
+      render template: "forms/welsh_translation/show_upload", locals: {
+        current_form: form,
+        welsh_translation_upload_input: welsh_translation_upload_input,
+      }
+    end
+
+    it "includes the row number in the error summary title" do
+      expect(rendered).to have_css(".govuk-error-summary__title", text: I18n.t("forms.welsh_translation.show_upload.error_summary_title_with_row_number", row_number: 2))
+      expect(rendered).to have_css(".govuk-error-message", text: "an error occurred")
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/35HPJgw3/3247-allow-uploading-a-csv-of-welsh-translations

Add validation to check the following when a CSV of Welsh translations is uploaded.

For selection questions, validate:
- The number of selection options match the current form
- The English content and order of selection options match the current form
- If some selection options for a question have been translated, all of them have been translated.

For question text and exit page headings, check that the English content in the uploaded CSV matches the English content for the current form. This should prevent assigning translations to the wrong questions/exit pages if the ordering changes.

For all other rows in the CSV, just check that the "Content ID" maps to content in the form. This is to prevent content being silently ignored if the form has changed since the CSV was downloaded, or if the "Content ID" column has been edited.

### How to test

1. Go to the Welsh translations task for a form and download the CSV
2. Complete the Welsh in the CSV
3. Visit `/forms/:form_id/welsh-translation-upload` to view the page to upload the CSV. E.g. https://pr-3089.admin.review.forms.service.gov.uk/forms/4/welsh-translation-upload

### Things to consider when reviewing

I'm open to suggestions for different ways of validating the content. I aimed for preventing translations being applied to the wrong fields or being silently ignored without being overly restrictive. 

<img width="1030" height="418" alt="Screenshot 2026-09-10 at 12 58 19" src="https://github.com/user-attachments/assets/9d91c0eb-dae2-4b0b-95a9-e89e406a6490" />

<img width="1030" height="429" alt="Screenshot 2026-09-10 at 10 00 14" src="https://github.com/user-attachments/assets/d8f248ca-dc3b-44ae-b4d8-fdf2673bf511" />

<img width="1030" height="394" alt="Screenshot 2026-09-10 at 10 00 29" src="https://github.com/user-attachments/assets/a2c3350a-6970-4ff0-9758-4732d850a5bf" />

<img width="1030" height="421" alt="Screenshot 2026-09-07 at 18 02 36" src="https://github.com/user-attachments/assets/3adc38f4-716e-483d-b4f8-787cd0487222" />

