### PR TITLE
Handle copying form document without available_languages

### DIFF
--- a/app/services/form_copy_service.rb
+++ b/app/services/form_copy_service.rb
@@ -39,7 +39,7 @@ class FormCopyService
       copy_group
 
       # Copy Welsh translations if available
-      if content["available_languages"].include?("cy")
+      if content&.[]("available_languages")&.include?("cy")
         copy_welsh_translations(tag:, version: form_doc.version)
       end
     rescue ActiveRecord::RecordInvalid => e

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -542,6 +542,17 @@ RSpec.describe FormCopyService do
       end
     end
 
+    context "when the FormDocument content does not include 'available_languages'" do
+      before do
+        live_form_document = source_form.latest_form_document
+        live_form_document.update!(content: live_form_document.content.except("available_languages"))
+      end
+
+      it "does not raise an error" do
+        expect { copied_form }.not_to raise_error
+      end
+    end
+
     context "when Welsh copy fails" do
       let(:source_form) do
         form = create(:form, :live, available_languages: %w[en cy])


### PR DESCRIPTION
We did not backfill available_languages to old form documents. Handle this field not being present.