### PR TITLE
Use declaration_markdown for Welsh CSV rather than declaration_text

### DIFF
--- a/app/services/welsh_csv_service.rb
+++ b/app/services/welsh_csv_service.rb
@@ -127,7 +127,7 @@ private
   end
 
   def add_form_metadata(csv)
-    add_field_if_present(csv, FORM_ATTRIBUTE_LABELS[:declaration_markdown], form.declaration_text, form.declaration_text_cy)
+    add_field_if_present(csv, FORM_ATTRIBUTE_LABELS[:declaration_markdown], form.declaration_markdown, form.declaration_markdown_cy)
     add_field_if_present(csv, FORM_ATTRIBUTE_LABELS[:what_happens_next_markdown], form.what_happens_next_markdown, form.what_happens_next_markdown_cy)
     add_field_if_present(csv, FORM_ATTRIBUTE_LABELS[:payment_url], form.payment_url, form.payment_url_cy)
     add_field_if_present(csv, FORM_ATTRIBUTE_LABELS[:privacy_policy_url], form.privacy_policy_url, form.privacy_policy_url_cy)

--- a/spec/services/welsh_csv_service_spec.rb
+++ b/spec/services/welsh_csv_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "WelshCsvService", feature_multiple_branches: false do
     end
 
     context "when the form has a declaration" do
-      let(:form) { build :form, declaration_text: "Declaration text", declaration_text_cy: "Welsh Declaration text" }
+      let(:form) { build :form, declaration_markdown: "Declaration text", declaration_markdown_cy: "Welsh Declaration text" }
 
       it "contains the declaration" do
         expect(csv_rows(form)).to include([
@@ -323,7 +323,7 @@ RSpec.describe "WelshCsvService", feature_multiple_branches: false do
               support_url_cy: "https://www.gov.uk/support_cy",
               support_url_text: "Support URL text",
               support_url_text_cy: "Welsh Support URL text",
-              declaration_text: "Declaration text",
+              declaration_markdown: "Declaration text",
               pages: [page, another_page]
       end
       let(:page) do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

`declaration_text` is deprecated and not set anywhere in the admin web interface or used anywhere in forms-runner, we shouldn't be using it in the Welsh translation CSV as the content could differ from the actual declaration in `declaration_markdown`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
