### PR TITLE
Delete routes to an exit page when that exit page is deleted

### DIFF
--- a/app/controllers/pages/exit_pages_controller.rb
+++ b/app/controllers/pages/exit_pages_controller.rb
@@ -53,6 +53,7 @@ class Pages::ExitPagesController < PagesController
     end
 
     current_form.save_question_changes! do
+      exit_page.conditions.destroy_all
       exit_page.destroy!
     end
 

--- a/app/views/pages/exit_pages/delete.html.erb
+++ b/app/views/pages/exit_pages/delete.html.erb
@@ -3,6 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if exit_page.conditions.any? && delete_confirmation_input.errors.blank? %>
+      <% routes = t("helpers.pages.routes", count: exit_page.conditions.size) %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+        <% banner.with_heading(text: t(".warnings.routes_will_be_deleted", routes:)) %>
+      <% end %>
+    <% end %>
+
     <%= render(
       delete_confirmation_input,
       url: exit_page_path(@current_form.id, page.id, exit_page.id),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1955,6 +1955,8 @@ en:
         back_link: Back to edit exit page
         caption: 'Exit page %{exit_page_number}: %{heading}'
         title: Are you sure you want to delete this exit page?
+        warnings:
+          routes_will_be_deleted: If you delete this exit page, the %{routes} to it will also be deleted
       edit:
         back_link: Back to edit question routes
         delete_exit_page: Delete exit page

--- a/spec/models/exit_page_spec.rb
+++ b/spec/models/exit_page_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ExitPage, type: :model do
   end
 
   describe "associations" do
-    let!(:question_page) { create(:page) }
+    let!(:question_page) { create(:page, :with_selection_settings) }
     let!(:exit_page) { create(:exit_page, question_page:) }
 
     it "has a question page" do
@@ -33,6 +33,27 @@ RSpec.describe ExitPage, type: :model do
 
     it "the page has exit pages" do
       expect(question_page.exit_pages).to eq([exit_page])
+    end
+
+    it "can have a condition" do
+      condition = create(:condition, routing_page: question_page, check_page: question_page, answer_value: "Option 1", exit_page:)
+
+      expect(exit_page.reload.conditions).to eq [
+        condition,
+      ]
+    end
+
+    it "can have more than one condition" do
+      create(:condition, routing_page: question_page, check_page: question_page, answer_value: "Option 1", exit_page:)
+      create(:condition, routing_page: question_page, check_page: question_page, answer_value: "Option 2", exit_page:)
+
+      expect(exit_page.reload.conditions.size).to eq 2
+    end
+
+    it "is not deleted when a condition is deleted" do
+      condition = create(:condition, routing_page: question_page, check_page: question_page, answer_value: "Option 1", exit_page:)
+
+      expect { condition.destroy! }.not_to change(described_class, :count)
     end
   end
 

--- a/spec/requests/pages/exit_pages_controller_spec.rb
+++ b/spec/requests/pages/exit_pages_controller_spec.rb
@@ -213,6 +213,22 @@ RSpec.describe Pages::ExitPagesController, :feature_multiple_branches, type: :re
         expect(response).to have_http_status :unprocessable_content
       end
     end
+
+    context "when the exit page has conditions" do
+      it "deletes the conditions" do
+        goto_page = create(:page, form: page.form)
+
+        exit_page.conditions << [
+          create(:condition, routing_page: page, check_page: page, answer_value: "Option 1"),
+          create(:condition, routing_page: page, check_page: page, answer_value: "Option 2"),
+        ]
+
+        skip_route = create(:condition, routing_page: page, check_page: page, answer_value: "Option 3", goto_page:)
+
+        expect { delete(exit_page_url, params:) }.to change(Condition, :count).by(-2)
+        expect(page.reload.routing_conditions).to eq [skip_route]
+      end
+    end
   end
 
   describe "#render_preview" do

--- a/spec/views/pages/exit_pages/delete.html.erb_spec.rb
+++ b/spec/views/pages/exit_pages/delete.html.erb_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "pages/exit_pages/delete" do
   let(:delete_confirmation_input) { Forms::DeleteConfirmationInput.new }
-  let(:current_form) { create :form }
-  let(:page) { create :page, form: current_form }
+  let(:current_form) { create :form, :ready_for_routing }
+  let(:page) { current_form.pages.first }
   let(:exit_page) { create :exit_page, question_page: page, heading: "the heading" }
 
   before do
@@ -38,6 +38,69 @@ RSpec.describe "pages/exit_pages/delete" do
 
     it "does not have a hint" do
       expect(rendered).not_to have_css ".govuk-hint"
+    end
+  end
+
+  context "when there are no routes to the exit page" do
+    it "does not have a notification banner" do
+      expect(rendered).not_to have_selector(".govuk-notification-banner")
+    end
+  end
+
+  context "when there is a route to the exit page" do
+    let(:exit_page) do
+      exit_page = super()
+      exit_page.conditions << create(:condition, routing_page: page, check_page: page, answer_value: "Option 1")
+      exit_page
+    end
+
+    it "has a notification banner with a warning message" do
+      expect(rendered).to have_selector(
+        ".govuk-notification-banner__content",
+        text: I18n.t("pages.exit_pages.delete.warnings.routes_will_be_deleted", routes: "route"),
+      )
+    end
+
+    context "and there is a validation error" do
+      let(:delete_confirmation_input) do
+        delete_confirmation_input = super()
+        delete_confirmation_input.validate
+        delete_confirmation_input
+      end
+
+      it "does not have a notification banner" do
+        expect(rendered).not_to have_selector(".govuk-notification-banner")
+      end
+    end
+  end
+
+  context "when there is more than one route to the exit page" do
+    let(:exit_page) do
+      exit_page = super()
+      exit_page.conditions << [
+        create(:condition, routing_page: page, check_page: page, answer_value: "Option 1"),
+        create(:condition, routing_page: page, check_page: page, answer_value: "Option 2"),
+      ]
+      exit_page
+    end
+
+    it "has a notification banner with a warning message" do
+      expect(rendered).to have_selector(
+        ".govuk-notification-banner__content",
+        text: I18n.t("pages.exit_pages.delete.warnings.routes_will_be_deleted", routes: "routes"),
+      )
+    end
+
+    context "and there is a validation error" do
+      let(:delete_confirmation_input) do
+        delete_confirmation_input = super()
+        delete_confirmation_input.validate
+        delete_confirmation_input
+      end
+
+      it "does not have a notification banner" do
+        expect(rendered).not_to have_selector(".govuk-notification-banner")
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Make sure conditions that route to an exit page are deleted with the exit page. Also add the warning message to the delete exit page page for this, from the designs in Mural (https://app.mural.co/t/gaap0347/m/gaap0347/1777554146285/b4db73fa35cee565fab61bb4ca050a371393e52f?wid=40-1782227043493).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
