### PR TITLE
Add save and return flag column

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -38,10 +38,16 @@ class Form < ApplicationRecord
     enabled: "enabled",
   }, prefix: :send_copy_of_answers
 
+  enum :save_and_return, {
+    disabled: "disabled",
+    enabled: "enabled",
+  }, prefix: :save_and_return
+
   validates :name, presence: true
   validates :payment_url, url: true, allow_blank: true
   validate :marking_complete_with_errors
   validates :send_copy_of_answers, presence: true
+  validates :save_and_return, presence: true
   validates :available_languages, presence: true, inclusion: { in: SUPPORTED_LANGUAGES }
   validates :submission_email, email_address: { message: :invalid_email }, allow_blank: true
   validates :support_email, email_address: { message: :invalid_email }, allow_blank: true

--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -31,6 +31,7 @@ class FormDocument::Content
   attribute :what_happens_next_markdown, :string
   attribute :send_copy_of_answers, :string
   attribute :delivery_configurations, array: true
+  attribute :save_and_return, :string
 
   alias_attribute :id, :form_id
 

--- a/db/migrate/20260910102253_add_save_and_return_to_forms.rb
+++ b/db/migrate/20260910102253_add_save_and_return_to_forms.rb
@@ -1,0 +1,5 @@
+class AddSaveAndReturnToForms < ActiveRecord::Migration[8.1]
+  def change
+    add_column :forms, :save_and_return, :string, null: false, default: "disabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_145418) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_10_102253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -210,6 +210,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_145418) do
     t.string "s3_bucket_aws_account_id"
     t.string "s3_bucket_name"
     t.string "s3_bucket_region"
+    t.string "save_and_return", default: "disabled", null: false
     t.string "send_copy_of_answers", default: "disabled", null: false
     t.boolean "share_preview_completed", default: false, null: false
     t.string "state"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -873,6 +873,20 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "save and return" do
+    describe "enum" do
+      it "returns a list of save and return values" do
+        expect(described_class.save_and_returns.keys).to eq(%w[disabled enabled])
+        expect(described_class.save_and_returns.values).to eq(%w[disabled enabled])
+      end
+    end
+
+    it "defaults to disabled" do
+      form = build(:form)
+      expect(form.save_and_return).to eq("disabled")
+    end
+  end
+
   describe "#destroy" do
     let(:form) { create :form }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6SzUYNnI/3271-add-a-database-column-for-whether-save-and-return-is-enabled-on-a-form

To support the feature we need to store when an editor denotes that the form they are creating will allow users to save and return to their submission. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
