### PR TITLE
Return version number in v3 live and archived responses

### DIFF
--- a/app/controllers/api/v3_form_documents_controller.rb
+++ b/app/controllers/api/v3_form_documents_controller.rb
@@ -18,23 +18,23 @@ class Api::V3FormDocumentsController < ApplicationController
   def live
     return head :gone if form.is_archived?
 
-    redirect_to_version
+    return_latest_version_number
   end
 
   def archived
     raise NotFoundError unless form.is_archived?
 
-    redirect_to_version
+    return_latest_version_number
   end
 
 private
 
-  def redirect_to_version
+  def return_latest_version_number
     latest_form_document = form.latest_form_document || (raise NotFoundError)
 
     CurrentLoggingAttributes.form_document_version = latest_form_document.version
 
-    redirect_to api_v3_form_document_version_url(form_id: form_id, version: latest_form_document.version)
+    render json: { version: latest_form_document.version }.to_json
   end
 
   def form

--- a/spec/requests/api/v3_form_documents_controller_spec.rb
+++ b/spec/requests/api/v3_form_documents_controller_spec.rb
@@ -133,9 +133,9 @@ RSpec.describe Api::V3FormDocumentsController, type: :request do
         form.update!(latest_form_document: form_document)
       end
 
-      it "redirects to the latest form document version" do
+      it "returns the latest form document version number" do
         get("/api/v3/forms/#{form.id}/versions/live", headers:)
-        expect(response).to redirect_to(api_v3_form_document_version_url(form_id: form.id, version: 2))
+        expect(response.parsed_body).to include({ version: 2 })
       end
     end
 
@@ -174,9 +174,9 @@ RSpec.describe Api::V3FormDocumentsController, type: :request do
         form.update!(latest_form_document: form_document)
       end
 
-      it "redirects to the latest form document version" do
+      it "returns the latest form document version number" do
         get("/api/v3/forms/#{form.id}/versions/archived", headers:)
-        expect(response).to redirect_to(api_v3_form_document_version_url(form_id: form.id, version: 2))
+        expect(response.parsed_body).to include({ version: 2 })
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/P7bDQZTP/3248-get-submission-delivery-configuration-from-latest-live-version-of-the-form-in-forms-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
These endpoints were returning a redirect to the latest form document. This causes some issues with ActiveRecord in forms-runner, because ActiveRecord:

- doesn't follow the redirect automatically
- automatically prefixes URLs with the base url, api prefix and resource name (e.g. `http://localhost:3000/api/v3/forms`), which means we can't use the absolute URL returned by the redirect directly.

Instead, this will now return a simple JSON response with the current version number - `{"version": 1}` - which forms-runner can easily use to generate a URL to request the latest version.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
