### PR TITLE
Ensure that unconditional routes are not deleted when changing answer settings

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -59,7 +59,7 @@ class Page < ApplicationRecord
       form.save_question_changes!
 
       if answer_type_changed_from_selection_only_one_option || answer_settings_changed_from_only_one_option
-        check_conditions.destroy_all
+        conditions_for_selection_options.destroy_all
         exit_pages.destroy_all
       end
     end
@@ -189,5 +189,9 @@ private
 
   def set_external_id
     self.external_id ||= ExternalIdProvider.generate_unique_id_for(Page)
+  end
+
+  def conditions_for_selection_options
+    routing_conditions.where.not(answer_value: nil)
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -481,7 +481,7 @@ RSpec.describe Page, type: :model do
     end
 
     context "when page has routing conditions and ExitPages" do
-      let(:routing_conditions) { [create(:condition)] }
+      let(:routing_conditions) { [create(:condition, answer_value: "Option 1")] }
       let(:check_conditions) { routing_conditions }
       let(:exit_page) { create :exit_page, question_page: page }
 
@@ -496,10 +496,11 @@ RSpec.describe Page, type: :model do
         expect(page.reload.exit_pages.to_a).to eq([exit_page])
       end
 
-      context "when answer type is updated to one doesn't support routing" do
+      context "when answer type is updated to one that doesn't support routing" do
         it "deletes any conditions" do
           page.answer_type = "number"
           page.save_and_update_form
+          expect(page.reload.routing_conditions).to be_empty
           expect(page.reload.check_conditions).to be_empty
         end
 
@@ -549,6 +550,106 @@ RSpec.describe Page, type: :model do
           page.answer_type = "number"
           page.save_and_update_form
           expect(page.reload.check_conditions).not_to be_empty
+        end
+      end
+    end
+
+    context "when page has secondary skip route" do
+      let(:check_page) { create :page, form: }
+      let(:routing_conditions) { [build(:condition, check_page:, answer_value: nil)] }
+      let(:check_conditions) { [] }
+
+      context "when answer type is updated to one that doesn't support routing" do
+        it "does not delete the secondary skip condition" do
+          page.answer_type = "number"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq routing_conditions
+        end
+      end
+
+      context "when the page is saved without changing the answer type" do
+        it "does not delete the secondary skip condition" do
+          page.question_text = "test"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq routing_conditions
+        end
+      end
+
+      context "when the answer settings no longer restrict to only one option" do
+        it "does not delete the secondary skip condition" do
+          page.answer_settings["only_one_option"] = "0"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq routing_conditions
+        end
+      end
+
+      context "when the answer settings change while still restricting to only one option" do
+        it "does not delete the secondary skip condition" do
+          page.answer_settings["selection_options"].first["name"] = "New option name"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq routing_conditions
+        end
+      end
+
+      context "when the answer type changes from selection with more than one option" do
+        subject(:page) { create :page, :selection_with_checkboxes, form:, routing_conditions:, check_conditions: }
+
+        it "does not delete the secondary skip condition" do
+          page.answer_type = "number"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq routing_conditions
+        end
+      end
+    end
+
+    context "when page has an unconditional route" do
+      let(:routing_conditions) { [build(:condition, answer_value: nil)] }
+      let(:check_conditions) { routing_conditions }
+
+      context "when answer type is updated to one that doesn't support routing" do
+        it "does not delete the unconditional route" do
+          page.answer_type = "number"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq(routing_conditions)
+          expect(page.reload.check_conditions).to eq(check_conditions)
+        end
+      end
+
+      context "when the page is saved without changing the answer type" do
+        it "does not delete the unconditional route" do
+          page.question_text = "test"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq(routing_conditions)
+          expect(page.reload.check_conditions).to eq(check_conditions)
+        end
+      end
+
+      context "when the answer settings no longer restrict to only one option" do
+        it "does not delete the unconditional route" do
+          page.answer_settings["only_one_option"] = "0"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq(routing_conditions)
+          expect(page.reload.check_conditions).to eq(check_conditions)
+        end
+      end
+
+      context "when the answer settings change while still restricting to only one option" do
+        it "does not delete the unconditional route" do
+          page.answer_settings["selection_options"].first["name"] = "New option name"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq(routing_conditions)
+          expect(page.reload.check_conditions).to eq(check_conditions)
+        end
+      end
+
+      context "when the answer type changes from selection with more than one option" do
+        subject(:page) { create :page, :selection_with_checkboxes, form:, routing_conditions:, check_conditions: }
+
+        it "does not delete the unconditional route" do
+          page.answer_type = "number"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).to eq(routing_conditions)
+          expect(page.reload.check_conditions).to eq(check_conditions)
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When the multiple branches feature is enabled, an only one option selection question can have an unconditional route if has more than 10 selection options (and didn't have any conditional routes added before the multiple branches feature was enabled).

We want to ensure that when the answer settings are changed for such a question that the unconditional route is not deleted.

This is similar to how (when the multiple branches feature is not enabled) we don't delete secondary skip conditions for a question when changing the answer settings.

Previously we were doing this by deleting only check conditions for a page, as secondary skip conditions have a different page for the routing and check pages. However, unconditional routes in the multiple branches feature do have the same check page as routing page, so this logic was deleting unconditional routes.

Instead, in this commit we delete only conditions that have non-nil `answer_value`. This excludes both unconditional routes and secondary skip conditions, and so should work when the multiple branches feature is either enabled or disabled.

Note: a warning message will be shown on the page to change the answer type for an only one option selection question with an unconditional route, that will be fixed in PR #3088.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
